### PR TITLE
Swapped out use of sincos() for more portability across platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,5 @@ benches/benchmark-data.*
 benches/*benchmarks_bar_plot*.png
 benches/__pycache__
 benches/elapsed_times.csv
+benches/bench_fftw
+

--- a/benches/main.c
+++ b/benches/main.c
@@ -46,7 +46,10 @@ void gen_random_signal(double* reals, double* imags, int num_amps) {
     for (int i = 0; i < num_amps; ++i) {
         double p_sqrt = sqrt(probs[i]);
         double sin_a, cos_a;
-        sincos(angles[i], &sin_a, &cos_a);
+
+        double theta = angles[i];
+        sin_a = sin(theta);
+        cos_a = cos(theta);
 
         double re = p_sqrt * cos_a;
         double im = p_sqrt * sin_a;


### PR DESCRIPTION
`sincos()` is a GNU extension provided by glibc.  With Xcode 15.1 on Apple Silicon, we get the following error:
```
gcc -Wall -Wextra -Werror -O3 -march=native -o bench_fftw main.c -lfftw3 -lm
main.c:49:9: error: call to undeclared function 'sincos'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        sincos(angles[i], &sin_a, &cos_a);
        ^
main.c:49:9: note: did you mean '__sincos'?
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/math.h:658:29: note: '__sincos' declared here
__header_always_inline void __sincos(double __x, double *__sinp, double *__cosp) {
```

We can, technically, use preprocessor directives to get around this; for example:
```main.c
        #ifdef __APPLE__
            __sincos(angles[i], &sin_a, &cos_a);
        #else
            sincos(angles[i], &sin_a, &cos_a);
        #endif
```

However, I feel that's not really elegant.  To improve portability across platforms, we should switch to invoking `sin()` and `cos()` separately.  Yes, this will be _theoretically_ slower -- BUT many good compilers can detect this situation and perform optimization as necessary:
<img width="1561" alt="Compiler optimizations" src="https://github.com/QuState/PhastFT/assets/1691596/74272371-a0f7-46e2-b1e1-56aba13575d4">
