### PR TITLE
Fixes inverse FFT ouput order issue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,8 @@ macro_rules! impl_fft_for {
                 Direction::Reverse => {
                     let scaling_factor = (reals.len() as $precision).recip();
                     for (z_re, z_im) in reals.iter_mut().zip(imags.iter_mut()) {
-                        *z_re = (*z_re) * scaling_factor;
-                        *z_im = -(*z_im) * -scaling_factor;
+                        *z_re *= scaling_factor;
+                        *z_im *= -scaling_factor;
                     }
                 }
                 _ => (),

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -6,6 +6,7 @@ use crate::twiddles::{generate_twiddles, generate_twiddles_simd_32, generate_twi
 
 /// Reverse is for running the Inverse Fast Fourier Transform (IFFT)
 /// Forward is for running the regular FFT
+#[derive(Copy, Clone)]
 pub enum Direction {
     /// Leave the exponent term in the twiddle factor alone
     Forward = 1,
@@ -46,9 +47,9 @@ macro_rules! impl_planner_for {
                 let dist = num_points >> 1;
 
                 let (twiddles_re, twiddles_im) = if dist >= 8 * 2 {
-                    $generate_twiddles_simd_fn(dist, direction)
+                    $generate_twiddles_simd_fn(dist, Direction::Forward)
                 } else {
-                    generate_twiddles(dist, direction)
+                    generate_twiddles(dist, Direction::Forward)
                 };
 
                 assert_eq!(twiddles_re.len(), twiddles_im.len());


### PR DESCRIPTION
This PR should address issue #24.

**TL;DR**

There's a bug in the original implementation of reverse (i.e., inverse FFT). I've yet to figure out a direct fix. Nevertheless, one can compute the inverse FFT using the forward FFT [1]. 

![Inverse_FFT_Figure4](https://github.com/QuState/PhastFT/assets/8347475/220c18a0-a894-47f9-9eac-15d126e31321)[2]

Note this is meant to be a stop-gap solution until I get to the bottom of the underlying issue. 

#### References
[[1]](https://adamsiembida.com/how-to-compute-the-ifft-using-only-the-forward-fft/)
[[2]](https://www.dsprelated.com/showarticle/800.php)