### PR TITLE
Make required cfg show up on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["quantum", "fft", "discrete", "fourier", "transform"]
 categories = ["algorithms", "compression", "science"]
 exclude = ["assets", "scripts", "benches"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 num-traits = "0.2.18"
 multiversion = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,6 @@ keywords = ["quantum", "fft", "discrete", "fourier", "transform"]
 categories = ["algorithms", "compression", "science"]
 exclude = ["assets", "scripts", "benches"]
 
-[package.metadata.docs.rs]
-all-features = true
-
 [dependencies]
 num-traits = "0.2.18"
 multiversion = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,10 +90,10 @@ macro_rules! impl_fft_interleaved_for {
     };
 }
 
-#[cfg_attr(ddocsrs, doc(cfg(feature = "complex-nums")))]
+#[doc(cfg(feature = "complex-nums"))]
 #[cfg(feature = "complex-nums")]
 impl_fft_interleaved_for!(fft_32_interleaved, f32, fft_32, deinterleave_complex32);
-#[cfg_attr(docsrs, doc(cfg(feature = "complex-nums")))]
+#[doc(cfg(feature = "complex-nums"))]
 #[cfg(feature = "complex-nums")]
 impl_fft_interleaved_for!(fft_64_interleaved, f64, fft_64, deinterleave_complex64);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,10 +90,10 @@ macro_rules! impl_fft_interleaved_for {
     };
 }
 
-#[cfg_attr(docs_rs, doc(cfg(feature = "complex-nums")))]
+#[cfg_attr(ddocsrs, doc(cfg(feature = "complex-nums")))]
 #[cfg(feature = "complex-nums")]
 impl_fft_interleaved_for!(fft_32_interleaved, f32, fft_32, deinterleave_complex32);
-#[cfg_attr(docs_rs, doc(cfg(feature = "complex-nums")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "complex-nums")))]
 #[cfg(feature = "complex-nums")]
 impl_fft_interleaved_for!(fft_64_interleaved, f64, fft_64, deinterleave_complex64);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 )]
 #![forbid(unsafe_code)]
 #![feature(portable_simd, avx512_target_feature)]
+#![feature(doc_cfg)]
 
 #[cfg(feature = "complex-nums")]
 use crate::utils::{combine_re_im, deinterleave_complex32, deinterleave_complex64};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,8 +90,10 @@ macro_rules! impl_fft_interleaved_for {
     };
 }
 
+#[cfg_attr(docs_rs, doc(cfg(feature = "complex-nums")))]
 #[cfg(feature = "complex-nums")]
 impl_fft_interleaved_for!(fft_32_interleaved, f32, fft_32, deinterleave_complex32);
+#[cfg_attr(docs_rs, doc(cfg(feature = "complex-nums")))]
 #[cfg(feature = "complex-nums")]
 impl_fft_interleaved_for!(fft_64_interleaved, f64, fft_64, deinterleave_complex64);
 


### PR DESCRIPTION
You can see an example of it in action on `tinyvec` documentation where they mark what functions require the `alloc` feature: https://docs.rs/tinyvec/latest/tinyvec/