### PR TITLE
Require gfni target feature for the AVX-512 codepath

### DIFF
--- a/src/algorithms/cobra.rs
+++ b/src/algorithms/cobra.rs
@@ -1076,10 +1076,10 @@ pub(crate) fn bit_reverse_permutation<T>(buf: &mut [T]) {
 /// [2] Christian Knauth, Boran Adas, Daniel Whitfield, Xuesong Wang, Lydia Ickler, Tim Conrad, Oliver Serang:
 /// Practically efficient methods for performing bit-reversed permutation in C++11 on the x86-64 architecture
 /// [3] <https://bitbucket.org/orserang/bit-reversal-methods/src/master/src_and_bin/src/algorithms/COBRAShuffle.hpp>
-#[multiversion::multiversion(targets("x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl", // x86_64-v4
+#[multiversion::multiversion(targets("x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
                                      "x86_64+avx2+fma", // x86_64-v3
                                      "x86_64+sse4.2", // x86_64-v2
-                                     "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+                                     "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
                                      "x86+avx2+fma",
                                      "x86+sse4.2",
                                      "x86+sse2",

--- a/src/algorithms/dif.rs
+++ b/src/algorithms/dif.rs
@@ -35,10 +35,10 @@ use crate::twiddles::filter_twiddles;
 ///
 /// Panics if input length is not a power of 2 or if real and imaginary arrays have different lengths
 #[multiversion::multiversion(
-    targets("x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl", // x86_64-v4
+    targets("x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
             "x86_64+avx2+fma", // x86_64-v3
             "x86_64+sse4.2", // x86_64-v2
-            "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+            "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
             "x86+avx2+fma",
             "x86+sse4.2",
             "x86+sse2",
@@ -144,10 +144,10 @@ pub fn fft_64_with_opts_and_plan(
 ///
 /// This is the core DIF implementation for single-precision floating point.
 #[multiversion::multiversion(targets(
-    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86_64+avx2+fma",
     "x86_64+sse4.2",
-    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86+avx2+fma",
     "x86+sse4.2",
     "x86+sse2",

--- a/src/kernels/common.rs
+++ b/src/kernels/common.rs
@@ -7,10 +7,10 @@ use num_traits::Float;
 /// Simple butterfly for chunk_size == 2
 /// This is the same for both, the DIF and DIT algorithms
 #[multiversion::multiversion(targets(
-    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86_64+avx2+fma",
     "x86_64+sse4.2",
-    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86+avx2+fma",
     "x86+sse4.2",
     "x86+sse2",
@@ -36,10 +36,10 @@ pub fn fft_chunk_2<T: Float>(reals: &mut [T], imags: &mut [T]) {
 
 /// DIF butterfly for chunk_size == 4 with hard-coded twiddle factors
 #[multiversion::multiversion(targets(
-    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86_64+avx2+fma",
     "x86_64+sse4.2",
-    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86+avx2+fma",
     "x86+sse4.2",
     "x86+sse2",

--- a/src/kernels/dif.rs
+++ b/src/kernels/dif.rs
@@ -8,10 +8,10 @@ use wide::{f32x16, f64x8};
 
 /// SIMD-optimized DIF butterfly for f64
 #[multiversion::multiversion(targets(
-    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86_64+avx2+fma",
     "x86_64+sse4.2",
-    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86+avx2+fma",
     "x86+sse4.2",
     "x86+sse2",
@@ -64,10 +64,10 @@ pub fn fft_64_chunk_n_simd(
 
 /// SIMD-optimized DIF butterfly for f32
 #[multiversion::multiversion(targets(
-    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86_64+avx2+fma",
     "x86_64+sse4.2",
-    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86+avx2+fma",
     "x86+sse4.2",
     "x86+sse2",
@@ -120,10 +120,10 @@ pub fn fft_32_chunk_n_simd(
 
 /// General-purpose DIF butterfly for arbitrary chunk sizes
 #[multiversion::multiversion(targets(
-    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86_64+avx2+fma",
     "x86_64+sse4.2",
-    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86+avx2+fma",
     "x86+sse4.2",
     "x86+sse2",

--- a/src/kernels/dit.rs
+++ b/src/kernels/dit.rs
@@ -18,10 +18,10 @@ pub fn fft_dit_chunk_2<T: Float>(reals: &mut [T], imags: &mut [T]) {
 
 /// DIT butterfly for chunk_size == 4 (f64)
 #[multiversion::multiversion(targets(
-    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86_64+avx2+fma",
     "x86_64+sse4.2",
-    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86+avx2+fma",
     "x86+sse4.2",
     "x86+sse2",
@@ -70,10 +70,10 @@ pub fn fft_dit_chunk_4_simd_f64(reals: &mut [f64], imags: &mut [f64]) {
 
 /// DIT butterfly for chunk_size == 4 (f32)
 #[multiversion::multiversion(targets(
-    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86_64+avx2+fma",
     "x86_64+sse4.2",
-    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86+avx2+fma",
     "x86+sse4.2",
     "x86+sse2",
@@ -122,10 +122,10 @@ pub fn fft_dit_chunk_4_simd_f32(reals: &mut [f32], imags: &mut [f32]) {
 
 /// DIT butterfly for chunk_size == 8 (f64) with SIMD
 #[multiversion::multiversion(targets(
-    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86_64+avx2+fma",
     "x86_64+sse4.2",
-    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86+avx2+fma",
     "x86+sse4.2",
     "x86+sse2",
@@ -180,10 +180,10 @@ pub fn fft_dit_chunk_8_simd_f64(reals: &mut [f64], imags: &mut [f64]) {
 
 /// DIT butterfly for chunk_size == 8 (f32) with SIMD
 #[multiversion::multiversion(targets(
-    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86_64+avx2+fma",
     "x86_64+sse4.2",
-    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86+avx2+fma",
     "x86+sse4.2",
     "x86+sse2",
@@ -238,10 +238,10 @@ pub fn fft_dit_chunk_8_simd_f32(reals: &mut [f32], imags: &mut [f32]) {
 
 /// DIT butterfly for chunk_size == 16 (f64)  
 #[multiversion::multiversion(targets(
-    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86_64+avx2+fma",
     "x86_64+sse4.2",
-    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86+avx2+fma",
     "x86+sse4.2",
     "x86+sse2",
@@ -306,10 +306,10 @@ pub fn fft_dit_chunk_16_simd_f64(reals: &mut [f64], imags: &mut [f64]) {
 
 /// DIT butterfly for chunk_size == 16 (f32)
 #[multiversion::multiversion(targets(
-    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86_64+avx2+fma",
     "x86_64+sse4.2",
-    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86+avx2+fma",
     "x86+sse4.2",
     "x86+sse2",
@@ -373,10 +373,10 @@ pub fn fft_dit_chunk_16_simd_f32(reals: &mut [f32], imags: &mut [f32]) {
 }
 /// DIT butterfly for chunk_size == 32 (f64)
 #[multiversion::multiversion(targets(
-    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86_64+avx2+fma",
     "x86_64+sse4.2",
-    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86+avx2+fma",
     "x86+sse4.2",
     "x86+sse2",
@@ -488,10 +488,10 @@ pub fn fft_dit_chunk_32_simd_f64(reals: &mut [f64], imags: &mut [f64]) {
 
 /// DIT butterfly for chunk_size == 32 (f32)
 #[multiversion::multiversion(targets(
-    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86_64+avx2+fma",
     "x86_64+sse4.2",
-    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86+avx2+fma",
     "x86+sse4.2",
     "x86+sse2",
@@ -571,10 +571,10 @@ pub fn fft_dit_chunk_32_simd_f32(reals: &mut [f32], imags: &mut [f32]) {
 
 /// DIT butterfly for chunk_size == 64 (f64)
 #[multiversion::multiversion(targets(
-    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86_64+avx2+fma",
     "x86_64+sse4.2",
-    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86+avx2+fma",
     "x86+sse4.2",
     "x86+sse2",
@@ -761,10 +761,10 @@ pub fn fft_dit_chunk_64_simd_f64(reals: &mut [f64], imags: &mut [f64]) {
 
 /// DIT butterfly for chunk_size == 64 (f32)
 #[multiversion::multiversion(targets(
-    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86_64+avx2+fma",
     "x86_64+sse4.2",
-    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86+avx2+fma",
     "x86+sse4.2",
     "x86+sse2",
@@ -902,10 +902,10 @@ pub fn fft_dit_chunk_64_simd_f32(reals: &mut [f32], imags: &mut [f32]) {
 
 /// General DIT butterfly for f64
 #[multiversion::multiversion(targets(
-    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86_64+avx2+fma",
     "x86_64+sse4.2",
-    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86+avx2+fma",
     "x86+sse4.2",
     "x86+sse2",
@@ -966,10 +966,10 @@ pub fn fft_dit_64_chunk_n_simd(
 
 /// General DIT butterfly for f32
 #[multiversion::multiversion(targets(
-    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86_64+avx2+fma",
     "x86_64+sse4.2",
-    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
     "x86+avx2+fma",
     "x86+sse4.2",
     "x86+sse2",

--- a/src/twiddles.rs
+++ b/src/twiddles.rs
@@ -187,10 +187,10 @@ generate_twiddles_simd!(generate_twiddles_simd_64, f64, 8, f64x8);
 generate_twiddles_simd!(generate_twiddles_simd_32, f32, 8, f32x8);
 
 #[multiversion::multiversion(
-                            targets("x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl", // x86_64-v4
+                            targets("x86_64+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
                                     "x86_64+avx2+fma", // x86_64-v3
                                     "x86_64+sse4.2", // x86_64-v2
-                                    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl",
+                                    "x86+avx512f+avx512bw+avx512cd+avx512dq+avx512vl+gfni",
                                     "x86+avx2+fma",
                                     "x86+sse4.2",
                                     "x86+sse2",


### PR DESCRIPTION
Boosts some of the benchmarks by 50% on Zen 4.

This instruction first appeared in 2019: https://en.wikipedia.org/wiki/Sunny_Cove_(microarchitecture)
Intel docs: https://builders.intel.com/docs/networkbuilders/galois-field-new-instructions-gfni-technology-guide-1-1639042826.pdf

On CPUs from before 2019 it's usually not worth it to use AVX-512 anyway because of the severe downlocking it induces.

Fixes #40