### PR TITLE
Use a fast, non-secure PRNG in benchmarking harness

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -8,7 +8,8 @@ use phastft::{
 };
 use rand::distr::StandardUniform;
 use rand::prelude::Distribution;
-use rand::{Rng, SeedableRng, rngs::SmallRng};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 use utilities::rustfft::num_complex::Complex;
 use utilities::rustfft::FftPlanner;
 


### PR DESCRIPTION
Prior to this PR the PRNG selected was ChaCha, which is a stream cipher that doubles a slow but cryptographically secure PRNG. In benchmarks generating the random numbers for each run was taking more time than the FFT itself.

This PR switches over to rand's default fast but non-cryptograpically-secure PRNG. It has very good statistical quality. The reported benchmark numbers are unaffected.