### PR TITLE
Drop lto=true from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ harness = false
 
 [profile.release]
 codegen-units = 1
-lto = true
 panic = "abort"
 
 [profile.profiling]


### PR DESCRIPTION
Not forcing LTO is more representative of how the crate would actually be used in third-party code.

It has no meaningful effect on benchmarks for PhastFT, but RustFFT is 15% faster on some sizes without LTO. This gives us a more accurate baseline. It also eases development - with LTO incremental build times are very long.