### PR TITLE
Benchmarks: Lower criterion sample size to 20 from its default of 100

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -69,6 +69,7 @@ fn benchmark_forward_f32(c: &mut Criterion) {
     group.plot_config(
         criterion::PlotConfiguration::default().summary_scale(criterion::AxisScale::Logarithmic),
     );
+    group.sample_size(20);
 
     for n in LENGTHS.iter() {
         let len = 1 << n;
@@ -129,6 +130,7 @@ fn benchmark_inverse_f32(c: &mut Criterion) {
     group.plot_config(
         criterion::PlotConfiguration::default().summary_scale(criterion::AxisScale::Logarithmic),
     );
+    group.sample_size(20);
 
     for n in LENGTHS.iter() {
         let len = 1 << n;
@@ -189,6 +191,7 @@ fn benchmark_forward_f64(c: &mut Criterion) {
     group.plot_config(
         criterion::PlotConfiguration::default().summary_scale(criterion::AxisScale::Logarithmic),
     );
+    group.sample_size(20);
 
     for n in LENGTHS.iter() {
         let len = 1 << n;
@@ -249,6 +252,7 @@ fn benchmark_inverse_f64(c: &mut Criterion) {
     group.plot_config(
         criterion::PlotConfiguration::default().summary_scale(criterion::AxisScale::Logarithmic),
     );
+    group.sample_size(20);
 
     for n in LENGTHS.iter() {
         let len = 1 << n;


### PR DESCRIPTION
Collecting 100 samples takes very long time because of our large number of benchmarks, and makes rayon confidently report 2-3% movements which are definitely just noise. This makes benchmarks both way faster and much more useful, we're not constantly drowning in noise anymore.