### PR TITLE
PoC: fused compute kernels

### DIFF
--- a/src/algorithms/dit.rs
+++ b/src/algorithms/dit.rs
@@ -20,7 +20,7 @@ use crate::kernels::dit::{
     fft_dit_chunk_16_simd_f64, fft_dit_chunk_2, fft_dit_chunk_32_simd_f32,
     fft_dit_chunk_32_simd_f64, fft_dit_chunk_4_simd_f32, fft_dit_chunk_4_simd_f64,
     fft_dit_chunk_64_simd_f32, fft_dit_chunk_64_simd_f64, fft_dit_chunk_8_simd_f32,
-    fft_dit_chunk_8_simd_f64,
+    fft_dit_chunk_8_simd_f64, fft_dit_chunk_fused_4_2_simd_f64,
 };
 use crate::options::Options;
 use crate::parallel::run_maybe_in_parallel;
@@ -154,10 +154,10 @@ fn execute_dit_stage_f64(
     let chunk_size = dist << 1;
 
     if chunk_size == 2 {
-        fft_dit_chunk_2(reals, imags);
+        //fft_dit_chunk_2(reals, imags);
         stage_twiddle_idx
     } else if chunk_size == 4 {
-        fft_dit_chunk_4_simd_f64(reals, imags);
+        fft_dit_chunk_fused_4_2_simd_f64(reals, imags);
         stage_twiddle_idx
     } else if chunk_size == 8 {
         fft_dit_chunk_8_simd_f64(reals, imags);


### PR DESCRIPTION
This is a naive way to perform f64 DIT for chunk sizes 2 and 4 in one function, removing the load/store overhead between these two stages since the whole thing can be kept in registers for the duration of the operation.