### PR TITLE
WIP: fused compute kernels

### DIFF
--- a/src/kernels/dit.rs
+++ b/src/kernels/dit.rs
@@ -1194,6 +1194,8 @@ fn fft_dit_chunk_n_simd_f32_fused<S: Simd>(
                         // given that modern CPUs are absurdly memory-bottlenecked
                         // this should help performance a lot, especially on larger sizes
 
+                        // TODO: this might be wrong. `chunk_size` changes between stages. Need to account for that.
+
                         let in0_re = out0_re;
                         let in0_im = out0_im;
                         let in1_re = out1_re;


### PR DESCRIPTION
The idea is to do twice the work per pass over memory. Code comments explain more.

https://fgiesen.wordpress.com/2023/03/19/notes-on-ffts-for-implementers/ calls this radix-2^2. It lets us keep the simple and SIMD-friendly bit reversal, but has the memory throughput efficiency almost double of the current impl and slightly better than even radix-4 because we need to load less twiddles. It would win on load/store efficiency even more if we were to ramp up the fusion factor instead of increasing the radix. 

