### PR TITLE
Refactor dit planner

### DIFF
--- a/src/planner.rs
+++ b/src/planner.rs
@@ -97,10 +97,10 @@ macro_rules! impl_planner_dit_for {
                 let log_n = num_points.ilog2() as usize;
                 let mut stage_twiddles = Vec::new();
 
-        // Pre-compute twiddles for each stage that needs them
-        for stage in 0..log_n {
-            let dist = 1 << stage; // 2.pow(stage)
-            let chunk_size = dist * 2;
+                // Pre-compute twiddles for each stage that needs them
+                for stage in 0..log_n {
+                    let dist = 1 << stage; // 2.pow(stage)
+                    let chunk_size = dist * 2;
 
                     // Only stages with chunk_size > 64 need twiddles (we have SIMD kernels up to 64)
                     if chunk_size > 64 {


### PR DESCRIPTION
Not sure why this one doesn't use the SIMD twiddle generation. That's a puzzle for later.