### PR TITLE
In place deinterleave

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ fftw = "0.8.0"
 rand = "0.9.2"
 utilities = { path = "utilities" }
 
+[[example]]
+name = "benchmark_interleaved"
+required-features = ["complex-nums"]
+
 [[bench]]
 name = "bench"
 harness = false

--- a/benches/interleave.rs
+++ b/benches/interleave.rs
@@ -1,5 +1,7 @@
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
-use phastft::complex_nums::{combine_re_im, deinterleave};
+use phastft::complex_nums::{
+    combine_re_im, deinterleave, deinterleave_inplace, interleave_inplace,
+};
 use rand::distr::StandardUniform;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
@@ -128,11 +130,121 @@ fn benchmark_combine_re_im_f64(c: &mut Criterion) {
     group.finish();
 }
 
+const BLOCK_SIZE_BYTES: usize = 8 * 1024;
+
+fn benchmark_interleave_inplace_f32(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Interleave inplace f32");
+    group.plot_config(
+        criterion::PlotConfiguration::default().summary_scale(criterion::AxisScale::Logarithmic),
+    );
+
+    let block_size = BLOCK_SIZE_BYTES / size_of::<f32>();
+
+    for n in LENGTHS.iter() {
+        let len = 1 << n;
+        if len < block_size * 2 {
+            continue;
+        }
+        group.throughput(Throughput::Bytes((len * 2 * size_of::<f32>()) as u64));
+
+        group.bench_function(BenchmarkId::new("interleave_inplace", len), |b| {
+            b.iter_batched(
+                || generate_interleaved_f32(len),
+                |mut data| interleave_inplace(&mut data, block_size),
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn benchmark_interleave_inplace_f64(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Interleave inplace f64");
+    group.plot_config(
+        criterion::PlotConfiguration::default().summary_scale(criterion::AxisScale::Logarithmic),
+    );
+
+    let block_size = BLOCK_SIZE_BYTES / size_of::<f64>();
+
+    for n in LENGTHS.iter() {
+        let len = 1 << n;
+        if len < block_size * 2 {
+            continue;
+        }
+        group.throughput(Throughput::Bytes((len * 2 * size_of::<f64>()) as u64));
+
+        group.bench_function(BenchmarkId::new("interleave_inplace", len), |b| {
+            b.iter_batched(
+                || generate_interleaved_f64(len),
+                |mut data| interleave_inplace(&mut data, block_size),
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn benchmark_deinterleave_inplace_f32(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Deinterleave inplace f32");
+    group.plot_config(
+        criterion::PlotConfiguration::default().summary_scale(criterion::AxisScale::Logarithmic),
+    );
+
+    let block_size = BLOCK_SIZE_BYTES / size_of::<f32>();
+
+    for n in LENGTHS.iter() {
+        let len = 1 << n;
+        if len < block_size * 2 {
+            continue;
+        }
+        group.throughput(Throughput::Bytes((len * 2 * size_of::<f32>()) as u64));
+
+        group.bench_function(BenchmarkId::new("deinterleave_inplace", len), |b| {
+            b.iter_batched(
+                || generate_interleaved_f32(len),
+                |mut data| deinterleave_inplace(&mut data, block_size),
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn benchmark_deinterleave_inplace_f64(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Deinterleave inplace f64");
+    group.plot_config(
+        criterion::PlotConfiguration::default().summary_scale(criterion::AxisScale::Logarithmic),
+    );
+
+    let block_size = BLOCK_SIZE_BYTES / size_of::<f64>();
+
+    for n in LENGTHS.iter() {
+        let len = 1 << n;
+        if len < block_size * 2 {
+            continue;
+        }
+        group.throughput(Throughput::Bytes((len * 2 * size_of::<f64>()) as u64));
+
+        group.bench_function(BenchmarkId::new("deinterleave_inplace", len), |b| {
+            b.iter_batched(
+                || generate_interleaved_f64(len),
+                |mut data| deinterleave_inplace(&mut data, block_size),
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     benchmark_deinterleave_f32,
     benchmark_deinterleave_f64,
     benchmark_combine_re_im_f32,
     benchmark_combine_re_im_f64,
+    benchmark_interleave_inplace_f32,
+    benchmark_interleave_inplace_f64,
+    benchmark_deinterleave_inplace_f32,
+    benchmark_deinterleave_inplace_f64,
 );
 criterion_main!(benches);

--- a/benches/interleave.rs
+++ b/benches/interleave.rs
@@ -11,7 +11,7 @@ use rand::{Rng, SeedableRng};
 // RUSTFLAGS="--cfg phastft_bench" cargo bench --bench interleave --features complex-nums
 
 const LENGTHS: &[usize] = &[
-    6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+    6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
 ];
 
 fn generate_interleaved_f32(n: usize) -> Vec<f32> {

--- a/examples/benchmark_interleaved.rs
+++ b/examples/benchmark_interleaved.rs
@@ -1,0 +1,79 @@
+use std::env;
+use std::str::FromStr;
+
+use num_complex::{Complex32, Complex64};
+use phastft::planner::{Direction, PlannerDit32, PlannerDit64};
+use phastft::{fft_32_interleaved_with_planner, fft_64_interleaved_with_planner};
+use utilities::{gen_random_signal_f32, gen_random_signal_f64};
+
+fn benchmark_fft_32_dit(n: usize, iterations: usize) {
+    let big_n = 1 << n; // 2.pow(n)
+    let mut reals = vec![0.0; big_n];
+    let mut imags = vec![0.0; big_n];
+    gen_random_signal_f32(&mut reals, &mut imags);
+    let mut signal = vec![Complex32::default(); big_n];
+    reals
+        .drain(..)
+        .zip(imags.drain(..))
+        .zip(signal.iter_mut())
+        .for_each(|((re, im), z)| {
+            z.re = re;
+            z.im = im;
+        });
+
+    // Pre-create planner for DIT
+    let planner = PlannerDit32::new(signal.len(), Direction::Forward);
+
+    let now = std::time::Instant::now();
+    for _ in 0..iterations {
+        fft_32_interleaved_with_planner(&mut signal, &planner);
+    }
+    let elapsed = now.elapsed().as_nanos();
+    let elapsed_per_iteration = elapsed / iterations as u128;
+    println!("{elapsed_per_iteration}");
+}
+
+fn benchmark_fft_64_dit(n: usize, iterations: usize) {
+    let big_n = 1 << n; // 2.pow(n)
+    let mut reals = vec![0.0; big_n];
+    let mut imags = vec![0.0; big_n];
+    gen_random_signal_f64(&mut reals, &mut imags);
+    let mut signal = vec![Complex64::default(); big_n];
+    reals
+        .drain(..)
+        .zip(imags.drain(..))
+        .zip(signal.iter_mut())
+        .for_each(|((re, im), z)| {
+            z.re = re;
+            z.im = im;
+        });
+
+    // Pre-create planner for DIT
+    let planner = PlannerDit64::new(signal.len(), Direction::Forward);
+
+    let now = std::time::Instant::now();
+    for _ in 0..iterations {
+        fft_64_interleaved_with_planner(&mut signal, &planner);
+    }
+    let elapsed = now.elapsed().as_nanos();
+    let elapsed_per_iteration = elapsed / iterations as u128;
+    println!("{elapsed_per_iteration}");
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    assert!(
+        args.len() >= 4,
+        "Usage {} <32|64> <n> <iterations>",
+        args[0]
+    );
+
+    let n = usize::from_str(&args[2]).unwrap();
+    let iterations = usize::from_str(&args[3]).unwrap();
+
+    match args[1].as_str() {
+        "32" => benchmark_fft_32_dit(n, iterations),
+        "64" => benchmark_fft_64_dit(n, iterations),
+        other => panic!("Invalid precision: {other}. Please pass 32 or 64"),
+    }
+}

--- a/src/complex_nums.rs
+++ b/src/complex_nums.rs
@@ -133,7 +133,7 @@ fn is_cycle_leader(val: usize, k: u32) -> bool {
 
 /// Performs an in-place interleaving of `[Reals | Imags]` into `[Re, Im, Re, Im...]`.
 /// `data.len()` and `block_size` must both be powers of 2.
-pub fn interleave_inplace<T: Copy + Default>(data: &mut [T], block_size: usize) {
+pub fn interleave_inplace<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
     let len = data.len();
     assert!(len.is_power_of_two(), "Data length must be a power of 2");
     assert!(
@@ -176,17 +176,34 @@ pub fn interleave_inplace<T: Copy + Default>(data: &mut [T], block_size: usize) 
     }
 
     // Phase 2: Local SIMD Interleave
-    interleave_blocks_inplace(data, block_size)
+    #[cfg(not(feature = "parallel"))]
+    interleave_blocks_inplace(data, block_size);
+    #[cfg(feature = "parallel")]
+    interleave_blocks_inplace_parallel(data, block_size);
 }
 
 /// Phase 2 of in-place block-based interleaving. Single-threaded.
 fn interleave_blocks_inplace<T: Copy + Default>(data: &mut [T], block_size: usize) {
     let mut temp_pair = vec![T::default(); 2 * block_size];
-    for window in data.chunks_exact_mut(2 * block_size) {
-        let (reals, imags) = window.split_at(block_size);
+    for chunk in data.chunks_exact_mut(2 * block_size) {
+        let (reals, imags) = chunk.split_at(block_size);
         combine_re_im_into(reals, imags, &mut temp_pair);
-        window.copy_from_slice(&temp_pair);
+        chunk.copy_from_slice(&temp_pair);
     }
+}
+
+#[cfg(feature = "parallel")]
+/// Phase 2 of in-place block-based interleaving. Multi-threaded through Rayon.
+fn interleave_blocks_inplace_parallel<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
+    use rayon::prelude::*;
+    data.par_chunks_exact_mut(2 * block_size).for_each_init(
+        || vec![T::default(); 2 * block_size],
+        |temp_pair, chunk| {
+            let (reals, imags) = chunk.split_at(block_size);
+            combine_re_im_into(reals, imags, temp_pair);
+            chunk.copy_from_slice(&temp_pair);
+        },
+    );
 }
 
 /// Reverses the in-place interleaving, returning `[Re, Im, ...]` back to `[Reals | Imags]`.

--- a/src/complex_nums.rs
+++ b/src/complex_nums.rs
@@ -176,6 +176,11 @@ pub fn interleave_inplace<T: Copy + Default>(data: &mut [T], block_size: usize) 
     }
 
     // Phase 2: Local SIMD Interleave
+    interleave_blocks_inplace(data, block_size)
+}
+
+/// Phase 2 of in-place block-based interleaving. Single-threaded.
+fn interleave_blocks_inplace<T: Copy + Default>(data: &mut [T], block_size: usize) {
     let mut temp_pair = vec![T::default(); 2 * block_size];
     for window in data.chunks_exact_mut(2 * block_size) {
         let (reals, imags) = window.split_at(block_size);

--- a/src/complex_nums.rs
+++ b/src/complex_nums.rs
@@ -185,16 +185,6 @@ pub fn interleave_inplace<T: Copy + Default + Send>(data: &mut [T], block_size: 
     }
 }
 
-/// Phase 2 of in-place block-based interleaving. Single-threaded.
-fn interleave_blocks_inplace<T: Copy + Default>(data: &mut [T], block_size: usize) {
-    let mut temp_pair = vec![T::default(); 2 * block_size];
-    for chunk in data.chunks_exact_mut(2 * block_size) {
-        let (reals, imags) = chunk.split_at(block_size);
-        combine_re_im_into(reals, imags, &mut temp_pair);
-        chunk.copy_from_slice(&temp_pair);
-    }
-}
-
 #[cfg(feature = "parallel")]
 /// Performs an in-place interleaving of `[Reals | Imags]` into `[Re, Im, Re, Im...]`.
 /// `data.len()` and `block_size` must both be powers of 2.
@@ -281,20 +271,6 @@ pub fn interleave_inplace_parallel<T: Copy + Default + Send>(data: &mut [T], blo
     // Phase 2: Local SIMD Interleave (parallel)
     // Reassemble data from the cycle slices — they're already written back
     // into the original data buffer since &mut [T] pointed into it.
-    data.par_chunks_exact_mut(2 * block_size).for_each_init(
-        || vec![T::default(); 2 * block_size],
-        |temp_pair, chunk| {
-            let (reals, imags) = chunk.split_at(block_size);
-            combine_re_im_into(reals, imags, temp_pair);
-            chunk.copy_from_slice(&temp_pair);
-        },
-    );
-}
-
-#[cfg(feature = "parallel")]
-/// Phase 2 of in-place block-based interleaving. Multi-threaded through Rayon.
-fn interleave_blocks_inplace_parallel<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
-    use rayon::prelude::*;
     data.par_chunks_exact_mut(2 * block_size).for_each_init(
         || vec![T::default(); 2 * block_size],
         |temp_pair, chunk| {

--- a/src/complex_nums.rs
+++ b/src/complex_nums.rs
@@ -3,7 +3,7 @@
 //! They are not part of the public API because the module they're in is private.
 //! They can be accessed with `--cfg phastft_bench` for benchmarking only.
 
-use bytemuck::cast_slice;
+use bytemuck::{cast_slice, Pod};
 use num_complex::Complex;
 use num_traits::Float;
 
@@ -16,25 +16,8 @@ pub fn deinterleave<T: Copy>(input: &[T]) -> (Vec<T>, Vec<T>) {
     input.chunks_exact(2).map(|c| (c[0], c[1])).unzip()
 }
 
-/// Utility function to separate a slice of [`Complex64``]
-/// into a single vector of Complex Number Structs.
-///
-/// # Panics
-///
-/// Panics if `reals.len() != imags.len()`.
-pub fn deinterleave_complex64(signal: &[Complex<f64>]) -> (Vec<f64>, Vec<f64>) {
-    let complex_t: &[f64] = cast_slice(signal);
-    deinterleave(complex_t)
-}
-
-/// Utility function to separate a slice of [`Complex32``]
-/// into a single vector of Complex Number Structs.
-///
-/// # Panics
-///
-/// Panics if `reals.len() != imags.len()`.
-pub fn deinterleave_complex32(signal: &[Complex<f32>]) -> (Vec<f32>, Vec<f32>) {
-    let complex_t: &[f32] = cast_slice(signal);
+pub fn deinterleave_complex<T: Float + Pod>(signal: &[Complex<T>]) -> (Vec<T>, Vec<T>) {
+    let complex_t: &[T] = cast_slice(signal);
     deinterleave(complex_t)
 }
 

--- a/src/complex_nums.rs
+++ b/src/complex_nums.rs
@@ -196,7 +196,7 @@ fn interleave_blocks_inplace<T: Copy + Default>(data: &mut [T], block_size: usiz
 #[cfg(feature = "parallel")]
 /// Performs an in-place interleaving of `[Reals | Imags]` into `[Re, Im, Re, Im...]`.
 /// `data.len()` and `block_size` must both be powers of 2.
-pub fn interleave_inplace<T: bytemuck::Pod + Send>(data: &mut [T], block_size: usize) {
+pub fn interleave_inplace<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
     interleave_inplace_parallel(data, block_size)
 }
 
@@ -204,8 +204,8 @@ pub fn interleave_inplace<T: bytemuck::Pod + Send>(data: &mut [T], block_size: u
 /// Both phases are parallelized via Rayon.
 /// `data.len()` and `block_size` must both be powers of 2.
 #[cfg(feature = "parallel")]
-pub fn interleave_inplace_parallel<T: bytemuck::Pod + Send>(data: &mut [T], block_size: usize) {
-    use std::cell::RefCell;
+pub fn interleave_inplace_parallel<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
+    use rayon::prelude::*;
 
     let len = data.len();
     assert!(len.is_power_of_two(), "Data length must be a power of 2");
@@ -221,69 +221,60 @@ pub fn interleave_inplace_parallel<T: bytemuck::Pod + Send>(data: &mut [T], bloc
     // Phase 1: Block Perfect Shuffle (Forward), parallelized.
     // Destination: block at position j moves to left_rotate(j, k).
     //
-    // We collect disjoint &mut slices for each cycle via Option::take(),
-    // then immediately spawn a rayon task to permute that cycle.
-    // This lets worker threads start processing cycles while the main thread
-    // is still discovering subsequent ones.
+    // We pre-compute all permutation cycles on the main thread by collecting
+    // disjoint &mut slices for each cycle. Then rayon applies each cycle's
+    // permutation in parallel, which is safe because cycles touch disjoint blocks.
 
     // Split data into one &mut slice per block.
     let mut block_slices: Vec<Option<&mut [T]>> =
         data.chunks_exact_mut(block_size).map(|s| Some(s)).collect();
 
+    // Collect cycles: for each cycle leader, gather its block slices.
     // Every cycle has length at most k (since multiplying by 2 mod 2^k-1
-    // loops back after exactly k steps).
+    // loops back after exactly k steps), so there are at most num_blocks/k cycles.
     let max_cycle_len = k as usize;
-
-    // Thread-local byte buffer reused across spawned tasks on the same thread.
-    thread_local! {
-        static TEMP_BUF: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
+    let mut cycles: Vec<Vec<&mut [T]>> = Vec::with_capacity(num_blocks / max_cycle_len.max(1));
+    for i in 0..num_blocks {
+        if is_cycle_leader(i, k) {
+            let mut cycle_slices = Vec::with_capacity(max_cycle_len);
+            let mut j = i;
+            loop {
+                cycle_slices.push(
+                    block_slices[j]
+                        .take()
+                        .expect("block already taken by another cycle"),
+                );
+                j = left_rotate(j, k);
+                if j == i {
+                    break;
+                }
+            }
+            cycles.push(cycle_slices);
+        }
     }
 
-    rayon::scope(|s| {
-        for i in 0..num_blocks {
-            if is_cycle_leader(i, k) {
-                let mut cycle_slices: Vec<&mut [T]> = Vec::with_capacity(max_cycle_len);
-                let mut j = i;
-                loop {
-                    cycle_slices.push(
-                        block_slices[j]
-                            .take()
-                            .expect("block already taken by another cycle"),
-                    );
-                    j = left_rotate(j, k);
-                    if j == i {
-                        break;
-                    }
-                }
-
-                // Spawn immediately — this cycle's slices are disjoint from all others.
-                s.spawn(move |_| {
-                    let cycle_len = cycle_slices.len();
-                    if cycle_len <= 1 {
-                        return;
-                    }
-                    TEMP_BUF.with(|cell| {
-                        let mut buf = cell.borrow_mut();
-                        let needed = block_size * std::mem::size_of::<T>();
-                        if buf.len() < needed {
-                            buf.resize(needed, 0);
-                        }
-                        let temp: &mut [T] = bytemuck::cast_slice_mut(&mut buf[..needed]);
-
-                        // Save the last block
-                        temp.copy_from_slice(&cycle_slices[cycle_len - 1]);
-                        // Shift each block one position forward (from the end)
-                        for idx in (1..cycle_len).rev() {
-                            let (left, right) = cycle_slices.split_at_mut(idx);
-                            right[0].copy_from_slice(&left[idx - 1]);
-                        }
-                        // Place saved block at position 0
-                        cycle_slices[0].copy_from_slice(temp);
-                    });
-                });
+    // Apply each cycle's permutation in parallel.
+    // The permutation moves content at cycle[n] to cycle[n+1], wrapping around.
+    // So we rotate slice contents: save the last, shift everything right by one,
+    // then place the saved last into position 0.
+    cycles.into_par_iter().for_each_init(
+        || vec![T::default(); block_size],
+        |temp, mut cycle_slices| {
+            let cycle_len = cycle_slices.len();
+            if cycle_len <= 1 {
+                return;
             }
-        }
-    });
+            // Save the last block
+            temp.copy_from_slice(&cycle_slices[cycle_len - 1]);
+            // Shift each block one position forward (from the end)
+            for idx in (1..cycle_len).rev() {
+                let (left, right) = cycle_slices.split_at_mut(idx);
+                right[0].copy_from_slice(&left[idx - 1]);
+            }
+            // Place saved block at position 0
+            cycle_slices[0].copy_from_slice(temp);
+        },
+    );
 
     // Phase 2: Local SIMD Interleave (parallel)
     // Reassemble data from the cycle slices — they're already written back
@@ -293,10 +284,10 @@ pub fn interleave_inplace_parallel<T: bytemuck::Pod + Send>(data: &mut [T], bloc
 
 #[cfg(feature = "parallel")]
 /// Phase 2 of in-place block-based interleaving. Multi-threaded through Rayon.
-fn interleave_blocks_inplace_parallel<T: bytemuck::Pod + Send>(data: &mut [T], block_size: usize) {
+fn interleave_blocks_inplace_parallel<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
     use rayon::prelude::*;
     data.par_chunks_exact_mut(2 * block_size).for_each_init(
-        || vec![T::zeroed(); 2 * block_size],
+        || vec![T::default(); 2 * block_size],
         |temp_pair, chunk| {
             let (reals, imags) = chunk.split_at(block_size);
             combine_re_im_into(reals, imags, temp_pair);

--- a/src/complex_nums.rs
+++ b/src/complex_nums.rs
@@ -196,7 +196,7 @@ fn interleave_blocks_inplace<T: Copy + Default>(data: &mut [T], block_size: usiz
 #[cfg(feature = "parallel")]
 /// Performs an in-place interleaving of `[Reals | Imags]` into `[Re, Im, Re, Im...]`.
 /// `data.len()` and `block_size` must both be powers of 2.
-pub fn interleave_inplace<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
+pub fn interleave_inplace<T: bytemuck::Pod + Send>(data: &mut [T], block_size: usize) {
     interleave_inplace_parallel(data, block_size)
 }
 
@@ -204,7 +204,9 @@ pub fn interleave_inplace<T: Copy + Default + Send>(data: &mut [T], block_size: 
 /// Both phases are parallelized via Rayon.
 /// `data.len()` and `block_size` must both be powers of 2.
 #[cfg(feature = "parallel")]
-pub fn interleave_inplace_parallel<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
+pub fn interleave_inplace_parallel<T: bytemuck::Pod + Send>(data: &mut [T], block_size: usize) {
+    use std::cell::RefCell;
+
     let len = data.len();
     assert!(len.is_power_of_two(), "Data length must be a power of 2");
     assert!(
@@ -232,6 +234,11 @@ pub fn interleave_inplace_parallel<T: Copy + Default + Send>(data: &mut [T], blo
     // loops back after exactly k steps).
     let max_cycle_len = k as usize;
 
+    // Thread-local byte buffer reused across spawned tasks on the same thread.
+    thread_local! {
+        static TEMP_BUF: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
+    }
+
     rayon::scope(|s| {
         for i in 0..num_blocks {
             if is_cycle_leader(i, k) {
@@ -255,17 +262,24 @@ pub fn interleave_inplace_parallel<T: Copy + Default + Send>(data: &mut [T], blo
                     if cycle_len <= 1 {
                         return;
                     }
-                    let mut temp = vec![T::default(); block_size];
+                    TEMP_BUF.with(|cell| {
+                        let mut buf = cell.borrow_mut();
+                        let needed = block_size * std::mem::size_of::<T>();
+                        if buf.len() < needed {
+                            buf.resize(needed, 0);
+                        }
+                        let temp: &mut [T] = bytemuck::cast_slice_mut(&mut buf[..needed]);
 
-                    // Save the last block
-                    temp.copy_from_slice(&cycle_slices[cycle_len - 1]);
-                    // Shift each block one position forward (from the end)
-                    for idx in (1..cycle_len).rev() {
-                        let (left, right) = cycle_slices.split_at_mut(idx);
-                        right[0].copy_from_slice(&left[idx - 1]);
-                    }
-                    // Place saved block at position 0
-                    cycle_slices[0].copy_from_slice(&temp);
+                        // Save the last block
+                        temp.copy_from_slice(&cycle_slices[cycle_len - 1]);
+                        // Shift each block one position forward (from the end)
+                        for idx in (1..cycle_len).rev() {
+                            let (left, right) = cycle_slices.split_at_mut(idx);
+                            right[0].copy_from_slice(&left[idx - 1]);
+                        }
+                        // Place saved block at position 0
+                        cycle_slices[0].copy_from_slice(temp);
+                    });
                 });
             }
         }
@@ -279,10 +293,10 @@ pub fn interleave_inplace_parallel<T: Copy + Default + Send>(data: &mut [T], blo
 
 #[cfg(feature = "parallel")]
 /// Phase 2 of in-place block-based interleaving. Multi-threaded through Rayon.
-fn interleave_blocks_inplace_parallel<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
+fn interleave_blocks_inplace_parallel<T: bytemuck::Pod + Send>(data: &mut [T], block_size: usize) {
     use rayon::prelude::*;
     data.par_chunks_exact_mut(2 * block_size).for_each_init(
-        || vec![T::default(); 2 * block_size],
+        || vec![T::zeroed(); 2 * block_size],
         |temp_pair, chunk| {
             let (reals, imags) = chunk.split_at(block_size);
             combine_re_im_into(reals, imags, temp_pair);

--- a/src/complex_nums.rs
+++ b/src/complex_nums.rs
@@ -294,7 +294,7 @@ mod tests {
     }
 
     #[test]
-    fn test_perfect_round_trip() {
+    fn test_perfect_round_trip_inplace() {
         let n = 2048;
         let block_size = 32; // Try tweaking this block size! (Must be a power of 2)
         let half = n / 2;

--- a/src/complex_nums.rs
+++ b/src/complex_nums.rs
@@ -177,10 +177,12 @@ pub fn interleave_inplace<T: Copy + Default + Send>(data: &mut [T], block_size: 
     }
 
     // Phase 2: Local SIMD Interleave
-    #[cfg(not(feature = "parallel"))]
-    interleave_blocks_inplace(data, block_size);
-    #[cfg(feature = "parallel")]
-    interleave_blocks_inplace_parallel(data, block_size);
+    let mut temp_pair = vec![T::default(); 2 * block_size];
+    for chunk in data.chunks_exact_mut(2 * block_size) {
+        let (reals, imags) = chunk.split_at(block_size);
+        combine_re_im_into(reals, imags, &mut temp_pair);
+        chunk.copy_from_slice(&temp_pair);
+    }
 }
 
 /// Phase 2 of in-place block-based interleaving. Single-threaded.
@@ -279,7 +281,14 @@ pub fn interleave_inplace_parallel<T: Copy + Default + Send>(data: &mut [T], blo
     // Phase 2: Local SIMD Interleave (parallel)
     // Reassemble data from the cycle slices — they're already written back
     // into the original data buffer since &mut [T] pointed into it.
-    interleave_blocks_inplace_parallel(data, block_size);
+    data.par_chunks_exact_mut(2 * block_size).for_each_init(
+        || vec![T::default(); 2 * block_size],
+        |temp_pair, chunk| {
+            let (reals, imags) = chunk.split_at(block_size);
+            combine_re_im_into(reals, imags, temp_pair);
+            chunk.copy_from_slice(&temp_pair);
+        },
+    );
 }
 
 #[cfg(feature = "parallel")]

--- a/src/complex_nums.rs
+++ b/src/complex_nums.rs
@@ -38,6 +38,23 @@ pub fn deinterleave_complex32(signal: &[Complex<f32>]) -> (Vec<f32>, Vec<f32>) {
     deinterleave(complex_t)
 }
 
+/// Separates data like `[1, 2, 3, 4]` into `([1, 3], [2, 4])` for any length,
+/// writing to existing output slices instead of allocating new Vecs.
+///
+/// # Panics
+///
+/// Panics if `output_a.len()` or `output_b.len()` does not equal `input.len() / 2`.
+pub fn deinterleave_into<T: Copy>(input: &[T], output_a: &mut [T], output_b: &mut [T]) {
+    let half = input.len() / 2;
+    assert_eq!(output_a.len(), half);
+    assert_eq!(output_b.len(), half);
+
+    for (i, c) in input.chunks_exact(2).enumerate() {
+        output_a[i] = c[0];
+        output_b[i] = c[1];
+    }
+}
+
 /// Utility function to combine separate vectors of real and imaginary components
 /// into a single vector of Complex Number Structs.
 ///
@@ -52,6 +69,21 @@ pub fn combine_re_im<T: Float>(reals: &[T], imags: &[T]) -> Vec<Complex<T>> {
         .zip(imags.iter())
         .map(|(z_re, z_im)| Complex::new(*z_re, *z_im))
         .collect()
+}
+
+/// Combines separate slices of real and imaginary components into an existing
+/// output slice of Complex Number Structs.
+///
+/// # Panics
+///
+/// Panics if `reals.len() != imags.len()` or `output.len() != reals.len()`.
+pub fn combine_re_im_into<T: Float>(reals: &[T], imags: &[T], output: &mut [Complex<T>]) {
+    assert_eq!(reals.len(), imags.len());
+    assert_eq!(output.len(), reals.len());
+
+    for ((out, z_re), z_im) in output.iter_mut().zip(reals.iter()).zip(imags.iter()) {
+        *out = Complex::new(*z_re, *z_im);
+    }
 }
 
 #[cfg(test)]
@@ -84,6 +116,20 @@ mod tests {
     }
 
     #[test]
+    fn deinterleave_into_correctness() {
+        for len in [0, 1, 2, 3, 15, 16, 17, 127, 128, 129, 130, 135, 100500] {
+            let input = gen_test_vec(len);
+            let half = len / 2;
+            let mut out_a = vec![0usize; half];
+            let mut out_b = vec![0usize; half];
+            deinterleave_into(&input, &mut out_a, &mut out_b);
+            let (expected_a, expected_b) = deinterleave(&input);
+            assert_eq!(out_a, expected_a);
+            assert_eq!(out_b, expected_b);
+        }
+    }
+
+    #[test]
     fn test_separate_and_combine_re_im() {
         let mut rng = SmallRng::from_os_rng();
         let complex_vec: Vec<f32> = (&mut rng)
@@ -97,5 +143,22 @@ mod tests {
 
         let recombined_flat: &[f32] = cast_slice(recombined_vec.as_slice());
         assert_eq!(complex_vec, recombined_flat);
+    }
+
+    #[test]
+    fn test_separate_and_combine_re_im_into() {
+        let mut rng = SmallRng::from_os_rng();
+        let complex_vec: Vec<f32> = (&mut rng)
+            .sample_iter(StandardUniform)
+            .take(16384)
+            .collect();
+
+        let (reals, imags) = deinterleave(&complex_vec);
+
+        let mut output = vec![Complex::new(0.0f32, 0.0f32); reals.len()];
+        combine_re_im_into(&reals, &imags, &mut output);
+
+        let output_flat: &[f32] = cast_slice(output.as_slice());
+        assert_eq!(complex_vec, output_flat);
     }
 }

--- a/src/complex_nums.rs
+++ b/src/complex_nums.rs
@@ -131,6 +131,7 @@ fn is_cycle_leader(val: usize, k: u32) -> bool {
 
 // MAIN IN-PLACE ALGORITHMS
 
+#[cfg(not(feature = "parallel"))]
 /// Performs an in-place interleaving of `[Reals | Imags]` into `[Re, Im, Re, Im...]`.
 /// `data.len()` and `block_size` must both be powers of 2.
 pub fn interleave_inplace<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
@@ -190,6 +191,95 @@ fn interleave_blocks_inplace<T: Copy + Default>(data: &mut [T], block_size: usiz
         combine_re_im_into(reals, imags, &mut temp_pair);
         chunk.copy_from_slice(&temp_pair);
     }
+}
+
+#[cfg(feature = "parallel")]
+/// Performs an in-place interleaving of `[Reals | Imags]` into `[Re, Im, Re, Im...]`.
+/// `data.len()` and `block_size` must both be powers of 2.
+pub fn interleave_inplace<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
+    interleave_inplace_parallel(data, block_size)
+}
+
+/// Performs an in-place interleaving of `[Reals | Imags]` into `[Re, Im, Re, Im...]`.
+/// Both phases are parallelized via Rayon.
+/// `data.len()` and `block_size` must both be powers of 2.
+#[cfg(feature = "parallel")]
+pub fn interleave_inplace_parallel<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
+    use rayon::prelude::*;
+
+    let len = data.len();
+    assert!(len.is_power_of_two(), "Data length must be a power of 2");
+    assert!(
+        block_size.is_power_of_two(),
+        "Block size must be a power of 2"
+    );
+    assert!(len >= block_size * 2, "Data must contain at least 2 blocks");
+
+    let num_blocks = len / block_size;
+    let k = num_blocks.trailing_zeros();
+
+    // Phase 1: Block Perfect Shuffle (Forward), parallelized.
+    // Destination: block at position j moves to left_rotate(j, k).
+    //
+    // We pre-compute all permutation cycles on the main thread by collecting
+    // disjoint &mut slices for each cycle. Then rayon applies each cycle's
+    // permutation in parallel, which is safe because cycles touch disjoint blocks.
+
+    // Split data into one &mut slice per block.
+    let mut block_slices: Vec<Option<&mut [T]>> =
+        data.chunks_exact_mut(block_size).map(|s| Some(s)).collect();
+
+    // Collect cycles: for each cycle leader, gather its block slices.
+    // Every cycle has length at most k (since multiplying by 2 mod 2^k-1
+    // loops back after exactly k steps), so there are at most num_blocks/k cycles.
+    let max_cycle_len = k as usize;
+    let mut cycles: Vec<Vec<&mut [T]>> = Vec::with_capacity(num_blocks / max_cycle_len.max(1));
+    for i in 0..num_blocks {
+        if is_cycle_leader(i, k) {
+            let mut cycle_slices = Vec::with_capacity(max_cycle_len);
+            let mut j = i;
+            loop {
+                cycle_slices.push(
+                    block_slices[j]
+                        .take()
+                        .expect("block already taken by another cycle"),
+                );
+                j = left_rotate(j, k);
+                if j == i {
+                    break;
+                }
+            }
+            cycles.push(cycle_slices);
+        }
+    }
+
+    // Apply each cycle's permutation in parallel.
+    // The permutation moves content at cycle[n] to cycle[n+1], wrapping around.
+    // So we rotate slice contents: save the last, shift everything right by one,
+    // then place the saved last into position 0.
+    cycles.into_par_iter().for_each_init(
+        || vec![T::default(); block_size],
+        |temp, mut cycle_slices| {
+            let cycle_len = cycle_slices.len();
+            if cycle_len <= 1 {
+                return;
+            }
+            // Save the last block
+            temp.copy_from_slice(&cycle_slices[cycle_len - 1]);
+            // Shift each block one position forward (from the end)
+            for idx in (1..cycle_len).rev() {
+                let (left, right) = cycle_slices.split_at_mut(idx);
+                right[0].copy_from_slice(&left[idx - 1]);
+            }
+            // Place saved block at position 0
+            cycle_slices[0].copy_from_slice(temp);
+        },
+    );
+
+    // Phase 2: Local SIMD Interleave (parallel)
+    // Reassemble data from the cycle slices — they're already written back
+    // into the original data buffer since &mut [T] pointed into it.
+    interleave_blocks_inplace_parallel(data, block_size);
 }
 
 #[cfg(feature = "parallel")]
@@ -345,6 +435,43 @@ mod tests {
 
         // Verify it correctly mapped back to[Reals | Imags]
         assert_eq!(data, original, "Reverse inplace deinterleave failed!");
+    }
+
+    #[test]
+    #[cfg(feature = "parallel")]
+    fn test_perfect_round_trip_inplace_parallel() {
+        for &block_size in &[1, 2, 4, 8, 16, 32] {
+            for &n in &[8, 16, 64, 256, 2048] {
+                if n < block_size * 2 {
+                    continue;
+                }
+                let half = n / 2;
+
+                let mut original = vec![0.0f32; n];
+                for i in 0..n {
+                    original[i] = i as f32;
+                }
+
+                let mut data = original.clone();
+                let expected_interleaved =
+                    interleave_out_of_place(&original[..half], &original[half..]);
+
+                interleave_inplace_parallel(&mut data, block_size);
+
+                assert_eq!(
+                    data, expected_interleaved,
+                    "Parallel forward interleave failed for n={n}, block_size={block_size}"
+                );
+
+                // Verify the parallel version matches the sequential version
+                let mut data_seq = original.clone();
+                interleave_inplace(&mut data_seq, block_size);
+                assert_eq!(
+                    data, data_seq,
+                    "Parallel and sequential interleave differ for n={n}, block_size={block_size}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/complex_nums.rs
+++ b/src/complex_nums.rs
@@ -152,7 +152,7 @@ pub fn interleave_inplace<T: Copy + Default + Send>(data: &mut [T], block_size: 
     for i in 0..num_blocks {
         if is_cycle_leader(i, k) {
             // Pick up the leader block
-            temp_block.copy_from_slice(&data[i * block_size..(i + 1) * block_size]);
+            temp_block.copy_from_slice(&data[i * block_size..][..block_size]);
 
             let mut hole = i;
             loop {
@@ -161,7 +161,7 @@ pub fn interleave_inplace<T: Copy + Default + Send>(data: &mut [T], block_size: 
 
                 if source == i {
                     // Loop closed, fill the final hole with the initial temp block
-                    data[hole * block_size..(hole + 1) * block_size].copy_from_slice(&temp_block);
+                    data[hole * block_size..][..block_size].copy_from_slice(&temp_block);
                     break;
                 }
 

--- a/src/complex_nums.rs
+++ b/src/complex_nums.rs
@@ -177,8 +177,7 @@ pub fn interleave_inplace<T: Copy + Default>(data: &mut [T], block_size: usize) 
 
     // Phase 2: Local SIMD Interleave
     let mut temp_pair = vec![T::default(); 2 * block_size];
-    for i in 0..(num_blocks / 2) {
-        let window = &mut data[2 * i * block_size..2 * (i + 1) * block_size];
+    for window in data.chunks_exact_mut(2 * block_size) {
         let (reals, imags) = window.split_at(block_size);
         combine_re_im_into(reals, imags, &mut temp_pair);
         window.copy_from_slice(&temp_pair);
@@ -202,8 +201,7 @@ pub fn deinterleave_inplace<T: Copy + Default>(data: &mut [T], block_size: usize
     let mut temp_re = vec![T::default(); block_size];
     let mut temp_im = vec![T::default(); block_size];
 
-    for i in 0..(num_blocks / 2) {
-        let window = &mut data[2 * i * block_size..2 * (i + 1) * block_size];
+    for window in data.chunks_exact_mut(2 * block_size) {
         deinterleave_into(window, &mut temp_re, &mut temp_im);
 
         // Write the newly split arrays back over the combined window

--- a/src/complex_nums.rs
+++ b/src/complex_nums.rs
@@ -3,7 +3,7 @@
 //! They are not part of the public API because the module they're in is private.
 //! They can be accessed with `--cfg phastft_bench` for benchmarking only.
 
-use bytemuck::{cast_slice, Pod};
+use bytemuck::{cast_slice, cast_slice_mut, Pod};
 use num_complex::Complex;
 use num_traits::Float;
 
@@ -42,6 +42,8 @@ pub fn combine_re_im<T: Float>(reals: &[T], imags: &[T]) -> Vec<Complex<T>> {
 
 // Overview of the algorithm and possible other approaches:
 // https://aistudio.google.com/app/prompts?state=%7B%22ids%22:%5B%221mYtdKnDYXiB5yj7GvxSgrc-McoGZfKoL%22%5D,%22action%22:%22open%22,%22userId%22:%22100773621717907681037%22,%22resourceKeys%22:%7B%7D%7D&usp=sharing
+
+const BLOCK_SIZE_BYTES: usize = 8 * 1024; // determined empirically
 
 // OUT-OF-PLACE FUNCTIONS FOR SMALL BLOCKS
 
@@ -114,10 +116,9 @@ fn is_cycle_leader(val: usize, k: u32) -> bool {
 
 // MAIN IN-PLACE ALGORITHMS
 
-#[cfg(not(feature = "parallel"))]
 /// Performs an in-place interleaving of `[Reals | Imags]` into `[Re, Im, Re, Im...]`.
 /// `data.len()` and `block_size` must both be powers of 2.
-pub fn interleave_inplace<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
+pub fn interleave_inplace_sequential<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
     let len = data.len();
     assert!(len.is_power_of_two(), "Data length must be a power of 2");
     assert!(
@@ -166,13 +167,6 @@ pub fn interleave_inplace<T: Copy + Default + Send>(data: &mut [T], block_size: 
         combine_re_im_into(reals, imags, &mut temp_pair);
         chunk.copy_from_slice(&temp_pair);
     }
-}
-
-#[cfg(feature = "parallel")]
-/// Performs an in-place interleaving of `[Reals | Imags]` into `[Re, Im, Re, Im...]`.
-/// `data.len()` and `block_size` must both be powers of 2.
-pub fn interleave_inplace<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
-    interleave_inplace_parallel(data, block_size)
 }
 
 /// Performs an in-place interleaving of `[Reals | Imags]` into `[Re, Im, Re, Im...]`.
@@ -264,9 +258,11 @@ pub fn interleave_inplace_parallel<T: Copy + Default + Send>(data: &mut [T], blo
     );
 }
 
-#[cfg(not(feature = "parallel"))]
 /// Reverses the in-place interleaving, returning `[Re, Im, ...]` back to `[Reals | Imags]`.
-pub fn deinterleave_inplace<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
+pub fn deinterleave_inplace_sequential<T: Copy + Default + Send>(
+    data: &mut [T],
+    block_size: usize,
+) {
     let len = data.len();
     assert!(len.is_power_of_two(), "Data length must be a power of 2");
     assert!(
@@ -320,11 +316,29 @@ pub fn deinterleave_inplace<T: Copy + Default + Send>(data: &mut [T], block_size
     }
 }
 
-#[cfg(feature = "parallel")]
 /// Reverses the in-place interleaving, returning `[Re, Im, ...]` back to `[Reals | Imags]`.
 /// `data.len()` and `block_size` must both be powers of 2.
-pub fn deinterleave_inplace<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
-    deinterleave_inplace_parallel(data, block_size)
+pub fn deinterleave_complex_inplace<T: Copy + Default + Send + Pod>(
+    data: &mut [Complex<T>],
+) -> (&mut [T], &mut [T]) {
+    let block_size = BLOCK_SIZE_BYTES / size_of::<T>();
+    let flat_data: &mut [T] = cast_slice_mut(data);
+    #[cfg(not(feature = "parallel"))]
+    deinterleave_inplace_sequential(flat_data, block_size);
+    #[cfg(feature = "parallel")]
+    deinterleave_inplace_parallel(flat_data, block_size);
+    flat_data.split_at_mut(flat_data.len() / 2)
+}
+
+/// Performs an in-place interleaving of `[Reals | Imags]` into `[Re, Im, Re, Im...]`.
+/// `data.len()` must be a power of 2.
+pub fn interleave_complex_inplace<T: Copy + Default + Send + Pod>(data: &mut [Complex<T>]) {
+    let block_size = BLOCK_SIZE_BYTES / size_of::<T>();
+    let flat_data: &mut [T] = cast_slice_mut(data);
+    #[cfg(not(feature = "parallel"))]
+    interleave_inplace_sequential(flat_data, block_size);
+    #[cfg(feature = "parallel")]
+    interleave_inplace_parallel(flat_data, block_size);
 }
 
 /// Reverses the in-place interleaving, returning `[Re, Im, ...]` back to `[Reals | Imags]`.
@@ -493,7 +507,7 @@ mod tests {
         let expected_interleaved = interleave_out_of_place(&original[..half], &original[half..]);
 
         // 2. Run our in-place forward algorithm
-        interleave_inplace(&mut data, block_size);
+        interleave_inplace_sequential(&mut data, block_size);
 
         // Verify it matches the standard out-of-place interleaving
         assert_eq!(
@@ -502,7 +516,7 @@ mod tests {
         );
 
         // 3. Run our in-place reverse algorithm
-        deinterleave_inplace(&mut data, block_size);
+        deinterleave_inplace_sequential(&mut data, block_size);
 
         // Verify it correctly mapped back to[Reals | Imags]
         assert_eq!(data, original, "Reverse inplace deinterleave failed!");
@@ -536,7 +550,7 @@ mod tests {
 
                 // Verify the parallel version matches the sequential version
                 let mut data_seq = original.clone();
-                interleave_inplace(&mut data_seq, block_size);
+                interleave_inplace_sequential(&mut data_seq, block_size);
                 assert_eq!(
                     data, data_seq,
                     "Parallel and sequential interleave differ for n={n}, block_size={block_size}"
@@ -574,7 +588,7 @@ mod tests {
 
                 // Verify the parallel version matches the sequential version
                 let mut data_seq = expected_interleaved.clone();
-                deinterleave_inplace(&mut data_seq, block_size);
+                deinterleave_inplace_sequential(&mut data_seq, block_size);
                 assert_eq!(
                     data, data_seq,
                     "Parallel and sequential deinterleave differ for n={n}, block_size={block_size}"
@@ -592,10 +606,10 @@ mod tests {
 
         let expected = interleave_out_of_place(&original[..4], &original[4..]);
 
-        interleave_inplace(&mut data, 1);
+        interleave_inplace_sequential(&mut data, 1);
         assert_eq!(data, expected);
 
-        deinterleave_inplace(&mut data, 1);
+        deinterleave_inplace_sequential(&mut data, 1);
         assert_eq!(data, original);
     }
 

--- a/src/complex_nums.rs
+++ b/src/complex_nums.rs
@@ -205,8 +205,6 @@ pub fn interleave_inplace<T: Copy + Default + Send>(data: &mut [T], block_size: 
 /// `data.len()` and `block_size` must both be powers of 2.
 #[cfg(feature = "parallel")]
 pub fn interleave_inplace_parallel<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
-    use rayon::prelude::*;
-
     let len = data.len();
     assert!(len.is_power_of_two(), "Data length must be a power of 2");
     assert!(
@@ -221,60 +219,57 @@ pub fn interleave_inplace_parallel<T: Copy + Default + Send>(data: &mut [T], blo
     // Phase 1: Block Perfect Shuffle (Forward), parallelized.
     // Destination: block at position j moves to left_rotate(j, k).
     //
-    // We pre-compute all permutation cycles on the main thread by collecting
-    // disjoint &mut slices for each cycle. Then rayon applies each cycle's
-    // permutation in parallel, which is safe because cycles touch disjoint blocks.
+    // We collect disjoint &mut slices for each cycle via Option::take(),
+    // then immediately spawn a rayon task to permute that cycle.
+    // This lets worker threads start processing cycles while the main thread
+    // is still discovering subsequent ones.
 
     // Split data into one &mut slice per block.
     let mut block_slices: Vec<Option<&mut [T]>> =
         data.chunks_exact_mut(block_size).map(|s| Some(s)).collect();
 
-    // Collect cycles: for each cycle leader, gather its block slices.
     // Every cycle has length at most k (since multiplying by 2 mod 2^k-1
-    // loops back after exactly k steps), so there are at most num_blocks/k cycles.
+    // loops back after exactly k steps).
     let max_cycle_len = k as usize;
-    let mut cycles: Vec<Vec<&mut [T]>> = Vec::with_capacity(num_blocks / max_cycle_len.max(1));
-    for i in 0..num_blocks {
-        if is_cycle_leader(i, k) {
-            let mut cycle_slices = Vec::with_capacity(max_cycle_len);
-            let mut j = i;
-            loop {
-                cycle_slices.push(
-                    block_slices[j]
-                        .take()
-                        .expect("block already taken by another cycle"),
-                );
-                j = left_rotate(j, k);
-                if j == i {
-                    break;
-                }
-            }
-            cycles.push(cycle_slices);
-        }
-    }
 
-    // Apply each cycle's permutation in parallel.
-    // The permutation moves content at cycle[n] to cycle[n+1], wrapping around.
-    // So we rotate slice contents: save the last, shift everything right by one,
-    // then place the saved last into position 0.
-    cycles.into_par_iter().for_each_init(
-        || vec![T::default(); block_size],
-        |temp, mut cycle_slices| {
-            let cycle_len = cycle_slices.len();
-            if cycle_len <= 1 {
-                return;
+    rayon::scope(|s| {
+        for i in 0..num_blocks {
+            if is_cycle_leader(i, k) {
+                let mut cycle_slices: Vec<&mut [T]> = Vec::with_capacity(max_cycle_len);
+                let mut j = i;
+                loop {
+                    cycle_slices.push(
+                        block_slices[j]
+                            .take()
+                            .expect("block already taken by another cycle"),
+                    );
+                    j = left_rotate(j, k);
+                    if j == i {
+                        break;
+                    }
+                }
+
+                // Spawn immediately — this cycle's slices are disjoint from all others.
+                s.spawn(move |_| {
+                    let cycle_len = cycle_slices.len();
+                    if cycle_len <= 1 {
+                        return;
+                    }
+                    let mut temp = vec![T::default(); block_size];
+
+                    // Save the last block
+                    temp.copy_from_slice(&cycle_slices[cycle_len - 1]);
+                    // Shift each block one position forward (from the end)
+                    for idx in (1..cycle_len).rev() {
+                        let (left, right) = cycle_slices.split_at_mut(idx);
+                        right[0].copy_from_slice(&left[idx - 1]);
+                    }
+                    // Place saved block at position 0
+                    cycle_slices[0].copy_from_slice(&temp);
+                });
             }
-            // Save the last block
-            temp.copy_from_slice(&cycle_slices[cycle_len - 1]);
-            // Shift each block one position forward (from the end)
-            for idx in (1..cycle_len).rev() {
-                let (left, right) = cycle_slices.split_at_mut(idx);
-                right[0].copy_from_slice(&left[idx - 1]);
-            }
-            // Place saved block at position 0
-            cycle_slices[0].copy_from_slice(temp);
-        },
-    );
+        }
+    });
 
     // Phase 2: Local SIMD Interleave (parallel)
     // Reassemble data from the cycle slices — they're already written back

--- a/src/complex_nums.rs
+++ b/src/complex_nums.rs
@@ -281,8 +281,9 @@ pub fn interleave_inplace_parallel<T: Copy + Default + Send>(data: &mut [T], blo
     );
 }
 
+#[cfg(not(feature = "parallel"))]
 /// Reverses the in-place interleaving, returning `[Re, Im, ...]` back to `[Reals | Imags]`.
-pub fn deinterleave_inplace<T: Copy + Default>(data: &mut [T], block_size: usize) {
+pub fn deinterleave_inplace<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
     let len = data.len();
     assert!(len.is_power_of_two(), "Data length must be a power of 2");
     assert!(
@@ -314,7 +315,7 @@ pub fn deinterleave_inplace<T: Copy + Default>(data: &mut [T], block_size: usize
     for i in 0..num_blocks {
         // We use the EXACT same cycle leader logic. The sets are identical!
         if is_cycle_leader(i, k) {
-            temp_block.copy_from_slice(&data[i * block_size..(i + 1) * block_size]);
+            temp_block.copy_from_slice(&data[i * block_size..][..block_size]);
 
             let mut hole = i;
             loop {
@@ -322,7 +323,7 @@ pub fn deinterleave_inplace<T: Copy + Default>(data: &mut [T], block_size: usize
                 let source = left_rotate(hole, k);
 
                 if source == i {
-                    data[hole * block_size..(hole + 1) * block_size].copy_from_slice(&temp_block);
+                    data[hole * block_size..][..block_size].copy_from_slice(&temp_block);
                     break;
                 }
 
@@ -334,6 +335,108 @@ pub fn deinterleave_inplace<T: Copy + Default>(data: &mut [T], block_size: usize
             }
         }
     }
+}
+
+#[cfg(feature = "parallel")]
+/// Reverses the in-place interleaving, returning `[Re, Im, ...]` back to `[Reals | Imags]`.
+/// `data.len()` and `block_size` must both be powers of 2.
+pub fn deinterleave_inplace<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
+    deinterleave_inplace_parallel(data, block_size)
+}
+
+/// Reverses the in-place interleaving, returning `[Re, Im, ...]` back to `[Reals | Imags]`.
+/// Both phases are parallelized via Rayon.
+/// `data.len()` and `block_size` must both be powers of 2.
+#[cfg(feature = "parallel")]
+pub fn deinterleave_inplace_parallel<T: Copy + Default + Send>(data: &mut [T], block_size: usize) {
+    use rayon::prelude::*;
+
+    let len = data.len();
+    assert!(len.is_power_of_two(), "Data length must be a power of 2");
+    assert!(
+        block_size.is_power_of_two(),
+        "Block size must be a power of 2"
+    );
+    assert!(len >= block_size * 2, "Data must contain at least 2 blocks");
+
+    let num_blocks = len / block_size;
+    let k = num_blocks.trailing_zeros();
+
+    // Phase 1: Local SIMD Deinterleave (parallel)
+    data.par_chunks_exact_mut(2 * block_size).for_each_init(
+        || {
+            (
+                vec![T::default(); block_size],
+                vec![T::default(); block_size],
+            )
+        },
+        |(temp_re, temp_im), window| {
+            deinterleave_into(window, temp_re, temp_im);
+
+            let (reals, imags) = window.split_at_mut(block_size);
+            reals.copy_from_slice(temp_re);
+            imags.copy_from_slice(temp_im);
+        },
+    );
+
+    // Phase 2: Block Perfect Unshuffle (Reverse), parallelized.
+    // Destination: block at position j moves to right_rotate(j, k).
+    //
+    // We pre-compute all permutation cycles on the main thread by collecting
+    // disjoint &mut slices for each cycle. Then rayon applies each cycle's
+    // permutation in parallel, which is safe because cycles touch disjoint blocks.
+
+    // Split data into one &mut slice per block.
+    let mut block_slices: Vec<Option<&mut [T]>> =
+        data.chunks_exact_mut(block_size).map(|s| Some(s)).collect();
+
+    // Collect cycles: for each cycle leader, gather its block slices.
+    // Every cycle has length at most k (since multiplying by 2 mod 2^k-1
+    // loops back after exactly k steps), so there are at most num_blocks/k cycles.
+    let max_cycle_len = k as usize;
+    let mut cycles: Vec<Vec<&mut [T]>> = Vec::with_capacity(num_blocks / max_cycle_len.max(1));
+    for i in 0..num_blocks {
+        if is_cycle_leader(i, k) {
+            let mut cycle_slices = Vec::with_capacity(max_cycle_len);
+            let mut j = i;
+            loop {
+                cycle_slices.push(
+                    block_slices[j]
+                        .take()
+                        .expect("block already taken by another cycle"),
+                );
+                j = left_rotate(j, k);
+                if j == i {
+                    break;
+                }
+            }
+            cycles.push(cycle_slices);
+        }
+    }
+
+    // Apply each cycle's permutation in parallel.
+    // For deinterleaving the permutation is the INVERSE of interleaving:
+    // content moves from cycle[n+1] to cycle[n], wrapping around.
+    // So we rotate slice contents LEFT: save the first, shift everything left by one,
+    // then place the saved first into the last position.
+    cycles.into_par_iter().for_each_init(
+        || vec![T::default(); block_size],
+        |temp, mut cycle_slices| {
+            let cycle_len = cycle_slices.len();
+            if cycle_len <= 1 {
+                return;
+            }
+            // Save the first block
+            temp.copy_from_slice(&cycle_slices[0]);
+            // Shift each block one position backward (from the start)
+            for idx in 0..cycle_len - 1 {
+                let (left, right) = cycle_slices.split_at_mut(idx + 1);
+                left[idx].copy_from_slice(&right[0]);
+            }
+            // Place saved block at the last position
+            cycle_slices[cycle_len - 1].copy_from_slice(temp);
+        },
+    );
 }
 
 #[cfg(test)]
@@ -454,6 +557,44 @@ mod tests {
                 assert_eq!(
                     data, data_seq,
                     "Parallel and sequential interleave differ for n={n}, block_size={block_size}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "parallel")]
+    fn test_perfect_round_trip_deinterleave_parallel() {
+        for &block_size in &[1, 2, 4, 8, 16, 32] {
+            for &n in &[8, 16, 64, 256, 2048] {
+                if n < block_size * 2 {
+                    continue;
+                }
+                let half = n / 2;
+
+                let mut original = vec![0.0f32; n];
+                for i in 0..n {
+                    original[i] = i as f32;
+                }
+
+                // Interleave first, then test that parallel deinterleave reverses it
+                let expected_interleaved =
+                    interleave_out_of_place(&original[..half], &original[half..]);
+
+                let mut data = expected_interleaved.clone();
+                deinterleave_inplace_parallel(&mut data, block_size);
+
+                assert_eq!(
+                    data, original,
+                    "Parallel deinterleave failed for n={n}, block_size={block_size}"
+                );
+
+                // Verify the parallel version matches the sequential version
+                let mut data_seq = expected_interleaved.clone();
+                deinterleave_inplace(&mut data_seq, block_size);
+                assert_eq!(
+                    data, data_seq,
+                    "Parallel and sequential deinterleave differ for n={n}, block_size={block_size}"
                 );
             }
         }

--- a/src/complex_nums.rs
+++ b/src/complex_nums.rs
@@ -38,23 +38,6 @@ pub fn deinterleave_complex32(signal: &[Complex<f32>]) -> (Vec<f32>, Vec<f32>) {
     deinterleave(complex_t)
 }
 
-/// Separates data like `[1, 2, 3, 4]` into `([1, 3], [2, 4])` for any length,
-/// writing to existing output slices instead of allocating new Vecs.
-///
-/// # Panics
-///
-/// Panics if `output_a.len()` or `output_b.len()` does not equal `input.len() / 2`.
-pub fn deinterleave_into<T: Copy>(input: &[T], output_a: &mut [T], output_b: &mut [T]) {
-    let half = input.len() / 2;
-    assert_eq!(output_a.len(), half);
-    assert_eq!(output_b.len(), half);
-
-    for (i, c) in input.chunks_exact(2).enumerate() {
-        output_a[i] = c[0];
-        output_b[i] = c[1];
-    }
-}
-
 /// Utility function to combine separate vectors of real and imaginary components
 /// into a single vector of Complex Number Structs.
 ///
@@ -71,18 +54,190 @@ pub fn combine_re_im<T: Float>(reals: &[T], imags: &[T]) -> Vec<Complex<T>> {
         .collect()
 }
 
-/// Combines separate slices of real and imaginary components into an existing
-/// output slice of Complex Number Structs.
-///
-/// # Panics
-///
-/// Panics if `reals.len() != imags.len()` or `output.len() != reals.len()`.
-pub fn combine_re_im_into<T: Float>(reals: &[T], imags: &[T], output: &mut [Complex<T>]) {
-    assert_eq!(reals.len(), imags.len());
-    assert_eq!(output.len(), reals.len());
+// FANCY IN-PLACE INTERLEAVING/DEINTERLEAVING
+// SPECIALIZED FOR BUFFERS WITH POWER OF 2 SIZE
 
-    for ((out, z_re), z_im) in output.iter_mut().zip(reals.iter()).zip(imags.iter()) {
-        *out = Complex::new(*z_re, *z_im);
+// Overview of the algorithm and possible other approaches:
+// https://aistudio.google.com/app/prompts?state=%7B%22ids%22:%5B%221mYtdKnDYXiB5yj7GvxSgrc-McoGZfKoL%22%5D,%22action%22:%22open%22,%22userId%22:%22100773621717907681037%22,%22resourceKeys%22:%7B%7D%7D&usp=sharing
+
+// OUT-OF-PLACE FUNCTIONS FOR SMALL BLOCKS
+
+/// Separates data like `[1, 2, 3, 4]` into `([1, 3], [2, 4])` for any length,
+/// writing to existing output slices instead of allocating new Vecs.
+pub fn deinterleave_into<T: Copy>(input: &[T], output_a: &mut [T], output_b: &mut [T]) {
+    let half = input.len() / 2;
+    assert_eq!(output_a.len(), half);
+    assert_eq!(output_b.len(), half);
+
+    for (i, c) in input.chunks_exact(2).enumerate() {
+        output_a[i] = c[0];
+        output_b[i] = c[1];
+    }
+}
+
+/// Combines parallel reals and imags arrays into an interleaved output.
+pub fn combine_re_im_into<T: Copy>(reals: &[T], imags: &[T], output: &mut [T]) {
+    assert_eq!(reals.len(), imags.len());
+    assert_eq!(output.len(), reals.len() * 2);
+
+    for ((out, z_re), z_im) in output
+        .chunks_exact_mut(2)
+        .zip(reals.iter())
+        .zip(imags.iter())
+    {
+        out[0] = *z_re;
+        out[1] = *z_im;
+    }
+}
+
+// CYCLE MATH (BIT ROTATIONS)
+
+/// Computes a circular left bit-shift of `val` for a `k`-bit integer.
+#[inline(always)]
+fn left_rotate(val: usize, k: u32) -> usize {
+    if k == 0 {
+        return val;
+    }
+    let mask = (1_usize << k) - 1;
+    ((val << 1) & mask) | (val >> (k - 1))
+}
+
+/// Computes a circular right bit-shift of `val` for a `k`-bit integer.
+#[inline(always)]
+fn right_rotate(val: usize, k: u32) -> usize {
+    if k == 0 {
+        return val;
+    }
+    (val >> 1) | ((val & 1) << (k - 1))
+}
+
+/// A block index is the "Cycle Leader" if it is the mathematical minimum
+/// of all its bit-rotations. This guarantees we only process a cycle once.
+fn is_cycle_leader(val: usize, k: u32) -> bool {
+    let mask = (1_usize << k) - 1;
+    if val == mask {
+        return true;
+    } // All 1s is always its own leader
+
+    let mut current = val;
+    for _ in 0..k {
+        current = left_rotate(current, k);
+        if current < val {
+            return false;
+        }
+    }
+    true
+}
+
+// MAIN IN-PLACE ALGORITHMS
+
+/// Performs an in-place interleaving of `[Reals | Imags]` into `[Re, Im, Re, Im...]`.
+/// `data.len()` and `block_size` must both be powers of 2.
+pub fn interleave_inplace<T: Copy + Default>(data: &mut [T], block_size: usize) {
+    let len = data.len();
+    assert!(len.is_power_of_two(), "Data length must be a power of 2");
+    assert!(
+        block_size.is_power_of_two(),
+        "Block size must be a power of 2"
+    );
+    assert!(len >= block_size * 2, "Data must contain at least 2 blocks");
+
+    let num_blocks = len / block_size;
+    let k = num_blocks.trailing_zeros(); // 2^k blocks
+
+    // Phase 1: Block Perfect Shuffle (Forward)
+    // Destination function: Left Rotate. Source function: Right Rotate.
+    let mut temp_block = vec![T::default(); block_size];
+
+    for i in 0..num_blocks {
+        if is_cycle_leader(i, k) {
+            // Pick up the leader block
+            temp_block.copy_from_slice(&data[i * block_size..(i + 1) * block_size]);
+
+            let mut hole = i;
+            loop {
+                // The block that *belongs* in the current hole
+                let source = right_rotate(hole, k);
+
+                if source == i {
+                    // Loop closed, fill the final hole with the initial temp block
+                    data[hole * block_size..(hole + 1) * block_size].copy_from_slice(&temp_block);
+                    break;
+                }
+
+                // Move the source block into the hole safely
+                data.copy_within(
+                    source * block_size..(source + 1) * block_size,
+                    hole * block_size,
+                );
+                hole = source;
+            }
+        }
+    }
+
+    // Phase 2: Local SIMD Interleave
+    let mut temp_pair = vec![T::default(); 2 * block_size];
+    for i in 0..(num_blocks / 2) {
+        let window = &mut data[2 * i * block_size..2 * (i + 1) * block_size];
+        let (reals, imags) = window.split_at(block_size);
+        combine_re_im_into(reals, imags, &mut temp_pair);
+        window.copy_from_slice(&temp_pair);
+    }
+}
+
+/// Reverses the in-place interleaving, returning `[Re, Im, ...]` back to `[Reals | Imags]`.
+pub fn deinterleave_inplace<T: Copy + Default>(data: &mut [T], block_size: usize) {
+    let len = data.len();
+    assert!(len.is_power_of_two(), "Data length must be a power of 2");
+    assert!(
+        block_size.is_power_of_two(),
+        "Block size must be a power of 2"
+    );
+    assert!(len >= block_size * 2, "Data must contain at least 2 blocks");
+
+    let num_blocks = len / block_size;
+    let k = num_blocks.trailing_zeros();
+
+    // Phase 1: Local SIMD Deinterleave
+    let mut temp_re = vec![T::default(); block_size];
+    let mut temp_im = vec![T::default(); block_size];
+
+    for i in 0..(num_blocks / 2) {
+        let window = &mut data[2 * i * block_size..2 * (i + 1) * block_size];
+        deinterleave_into(window, &mut temp_re, &mut temp_im);
+
+        // Write the newly split arrays back over the combined window
+        let (reals, imags) = window.split_at_mut(block_size);
+        reals.copy_from_slice(&temp_re);
+        imags.copy_from_slice(&temp_im);
+    }
+
+    // Phase 2: Block Perfect Unshuffle (Reverse)
+    // Destination function: Right Rotate. Source function: Left Rotate.
+    let mut temp_block = vec![T::default(); block_size];
+
+    for i in 0..num_blocks {
+        // We use the EXACT same cycle leader logic. The sets are identical!
+        if is_cycle_leader(i, k) {
+            temp_block.copy_from_slice(&data[i * block_size..(i + 1) * block_size]);
+
+            let mut hole = i;
+            loop {
+                // The ONLY DIFFERENCE from Phase 1: Source is now computed via Left Rotate
+                let source = left_rotate(hole, k);
+
+                if source == i {
+                    data[hole * block_size..(hole + 1) * block_size].copy_from_slice(&temp_block);
+                    break;
+                }
+
+                data.copy_within(
+                    source * block_size..(source + 1) * block_size,
+                    hole * block_size,
+                );
+                hole = source;
+            }
+        }
     }
 }
 
@@ -116,20 +271,6 @@ mod tests {
     }
 
     #[test]
-    fn deinterleave_into_correctness() {
-        for len in [0, 1, 2, 3, 15, 16, 17, 127, 128, 129, 130, 135, 100500] {
-            let input = gen_test_vec(len);
-            let half = len / 2;
-            let mut out_a = vec![0usize; half];
-            let mut out_b = vec![0usize; half];
-            deinterleave_into(&input, &mut out_a, &mut out_b);
-            let (expected_a, expected_b) = deinterleave(&input);
-            assert_eq!(out_a, expected_a);
-            assert_eq!(out_b, expected_b);
-        }
-    }
-
-    #[test]
     fn test_separate_and_combine_re_im() {
         let mut rng = SmallRng::from_os_rng();
         let complex_vec: Vec<f32> = (&mut rng)
@@ -145,6 +286,77 @@ mod tests {
         assert_eq!(complex_vec, recombined_flat);
     }
 
+    // Naive out-of-place implementations to test against
+    fn interleave_out_of_place(reals: &[f32], imags: &[f32]) -> Vec<f32> {
+        reals
+            .iter()
+            .zip(imags.iter())
+            .flat_map(|(r, i)| vec![*r, *i])
+            .collect()
+    }
+
+    #[test]
+    fn test_perfect_round_trip() {
+        let n = 2048;
+        let block_size = 32; // Try tweaking this block size! (Must be a power of 2)
+        let half = n / 2;
+
+        let mut original = vec![0.0; n];
+        for i in 0..n {
+            original[i] = i as f32;
+        }
+
+        let mut data = original.clone();
+
+        // 1. Generate the expected "truth" array using out-of-place allocation
+        let expected_interleaved = interleave_out_of_place(&original[..half], &original[half..]);
+
+        // 2. Run our in-place forward algorithm
+        interleave_inplace(&mut data, block_size);
+
+        // Verify it matches the standard out-of-place interleaving
+        assert_eq!(
+            data, expected_interleaved,
+            "Forward inplace interleave failed!"
+        );
+
+        // 3. Run our in-place reverse algorithm
+        deinterleave_inplace(&mut data, block_size);
+
+        // Verify it correctly mapped back to[Reals | Imags]
+        assert_eq!(data, original, "Reverse inplace deinterleave failed!");
+    }
+
+    #[test]
+    fn test_tiny_blocks() {
+        // Edge Case: Block size is 1. All work is handled by Phase 1 swapping.
+        // Phase 2 will just do a 1-to-1 copy in place.
+        let mut data = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]; // 8 elements
+        let original = data.clone();
+
+        let expected = interleave_out_of_place(&original[..4], &original[4..]);
+
+        interleave_inplace(&mut data, 1);
+        assert_eq!(data, expected);
+
+        deinterleave_inplace(&mut data, 1);
+        assert_eq!(data, original);
+    }
+
+    #[test]
+    fn deinterleave_into_correctness() {
+        for len in [0, 1, 2, 3, 15, 16, 17, 127, 128, 129, 130, 135, 100500] {
+            let input = gen_test_vec(len);
+            let half = len / 2;
+            let mut out_a = vec![0usize; half];
+            let mut out_b = vec![0usize; half];
+            deinterleave_into(&input, &mut out_a, &mut out_b);
+            let (expected_a, expected_b) = deinterleave(&input);
+            assert_eq!(out_a, expected_a);
+            assert_eq!(out_b, expected_b);
+        }
+    }
+
     #[test]
     fn test_separate_and_combine_re_im_into() {
         let mut rng = SmallRng::from_os_rng();
@@ -155,7 +367,7 @@ mod tests {
 
         let (reals, imags) = deinterleave(&complex_vec);
 
-        let mut output = vec![Complex::new(0.0f32, 0.0f32); reals.len()];
+        let mut output = vec![0.0f32; reals.len() * 2];
         combine_re_im_into(&reals, &imags, &mut output);
 
         let output_flat: &[f32] = cast_slice(output.as_slice());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 use num_complex::Complex;
 
 #[cfg(feature = "complex-nums")]
-use crate::complex_nums::{combine_re_im, deinterleave_complex};
+use crate::complex_nums::{deinterleave_complex_inplace, interleave_complex_inplace};
 use crate::options::Options;
 use crate::planner::{Direction, PlannerDit32, PlannerDit64};
 
@@ -42,9 +42,11 @@ macro_rules! impl_fft_interleaved_for {
         /// **Note**: This function has to make a deinterleaved copy of the data.
         /// For maximum performance with minimal memory usage, use [fft_64_dit_with_planner_and_opts].
         pub fn $func_name(signal: &mut [Complex<$precision>], planner: &$planner, opts: &Options) {
-            let (mut reals, mut imags) = deinterleave_complex(signal);
-            $fft_func(&mut reals, &mut imags, planner, opts);
-            signal.copy_from_slice(&combine_re_im(&reals, &imags))
+            {
+                let (reals, imags) = deinterleave_complex_inplace(signal);
+                $fft_func(reals, imags, planner, opts);
+            }
+            interleave_complex_inplace(signal);
         }
     };
 }
@@ -307,7 +309,7 @@ mod tests {
     #[cfg(feature = "complex-nums")]
     #[test]
     fn fft_interleaved_correctness() {
-        let n = 10;
+        let n = 14;
         let big_n = 1 << n; // 2.pow(n)
         let mut actual_signal: Vec<_> = (1..=big_n).map(|i| Complex::new(i as f64, 0.0)).collect();
         let mut expected_reals: Vec<_> = (1..=big_n).map(|i| i as f64).collect();
@@ -325,7 +327,7 @@ mod tests {
                 assert_float_closeness(z.im, z_im, 1e-10);
             });
 
-        let n = 10;
+        let n = 14;
         let big_n = 1 << n; // 2.pow(n)
         let mut actual_signal: Vec<_> = (1..=big_n).map(|i| Complex::new(i as f32, 0.0)).collect();
         let mut expected_reals: Vec<_> = (1..=big_n).map(|i| i as f32).collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 use num_complex::Complex;
 
 #[cfg(feature = "complex-nums")]
-use crate::complex_nums::{combine_re_im, deinterleave_complex32, deinterleave_complex64};
+use crate::complex_nums::{combine_re_im, deinterleave_complex};
 use crate::options::Options;
 use crate::planner::{Direction, PlannerDit32, PlannerDit64};
 
@@ -33,7 +33,7 @@ pub use algorithms::dit::{fft_32_dit_with_planner_and_opts, fft_64_dit_with_plan
 
 #[cfg(feature = "complex-nums")]
 macro_rules! impl_fft_interleaved_for {
-    ($func_name:ident, $precision:ty, $fft_func:ident, $deinterleaving_func: ident, $planner:ty) => {
+    ($func_name:ident, $precision:ty, $fft_func:ident, $planner:ty) => {
         /// FFT Interleaved -- this is an alternative to [`fft_64`]/[`fft_32`] in the case where
         /// the input data is a array of [`Complex`].
         ///
@@ -42,7 +42,7 @@ macro_rules! impl_fft_interleaved_for {
         /// **Note**: This function has to make a deinterleaved copy of the data.
         /// For maximum performance with minimal memory usage, use [fft_64_dit_with_planner_and_opts].
         pub fn $func_name(signal: &mut [Complex<$precision>], planner: &$planner, opts: &Options) {
-            let (mut reals, mut imags) = $deinterleaving_func(signal);
+            let (mut reals, mut imags) = deinterleave_complex(signal);
             $fft_func(&mut reals, &mut imags, planner, opts);
             signal.copy_from_slice(&combine_re_im(&reals, &imags))
         }
@@ -54,7 +54,6 @@ impl_fft_interleaved_for!(
     fft_32_interleaved_with_planner_and_opts,
     f32,
     fft_32_dit_with_planner_and_opts,
-    deinterleave_complex32,
     PlannerDit32
 );
 #[cfg(feature = "complex-nums")]
@@ -62,7 +61,6 @@ impl_fft_interleaved_for!(
     fft_64_interleaved_with_planner_and_opts,
     f64,
     fft_64_dit_with_planner_and_opts,
-    deinterleave_complex64,
     PlannerDit64
 );
 


### PR DESCRIPTION
Addresses #93

WIP. Works but needs tuning for parallelism to switch on/off at a given size. I don't think there's a way around measuring how each approach performs at runtime because there isn't a portable way to get cache information and there's a very sudden switch from single-threaded to multi-threaded being beneficial as we leave the cache and hit the memory wall.

There's also a very sudden transition from out-of-place being faster to in-place being faster as we leave the cache on Zen4, but Apple M4 is not affected by that and keeps out-of-place performance almost unchanged far past the advertised cache size. That is a rather surprising result.