### PR TITLE
PoC: compute twiddles on the fly

### DIFF
--- a/src/algorithms/dit.rs
+++ b/src/algorithms/dit.rs
@@ -34,24 +34,14 @@ fn recursive_dit_fft_f64<S: Simd>(
     reals: &mut [f64],
     imags: &mut [f64],
     size: usize,
-    planner: &PlannerDit64,
     opts: &Options,
-    mut stage_twiddle_idx: usize,
-) -> usize {
+) {
     let log_size = size.ilog2() as usize;
 
     if size <= L1_BLOCK_SIZE {
         for stage in 0..log_size {
-            stage_twiddle_idx = execute_dit_stage_f64(
-                simd,
-                &mut reals[..size],
-                &mut imags[..size],
-                stage,
-                planner,
-                stage_twiddle_idx,
-            );
+            execute_dit_stage_f64(simd, &mut reals[..size], &mut imags[..size], stage);
         }
-        stage_twiddle_idx
     } else {
         let half = size / 2;
         let log_half = half.ilog2() as usize;
@@ -61,27 +51,14 @@ fn recursive_dit_fft_f64<S: Simd>(
         // Recursively process both halves
         run_maybe_in_parallel(
             size > opts.smallest_parallel_chunk_size,
-            || recursive_dit_fft_f64(simd, re_first_half, im_first_half, half, planner, opts, 0),
-            || recursive_dit_fft_f64(simd, re_second_half, im_second_half, half, planner, opts, 0),
+            || recursive_dit_fft_f64(simd, re_first_half, im_first_half, half, opts),
+            || recursive_dit_fft_f64(simd, re_second_half, im_second_half, half, opts),
         );
-
-        // Both halves completed stages 0..log_half-1
-        // Stages 0-5 use hardcoded twiddles, 6+ use planner
-        stage_twiddle_idx = log_half.saturating_sub(6);
 
         // Process remaining stages that span both halves
         for stage in log_half..log_size {
-            stage_twiddle_idx = execute_dit_stage_f64(
-                simd,
-                &mut reals[..size],
-                &mut imags[..size],
-                stage,
-                planner,
-                stage_twiddle_idx,
-            );
+            execute_dit_stage_f64(simd, &mut reals[..size], &mut imags[..size], stage);
         }
-
-        stage_twiddle_idx
     }
 }
 
@@ -91,24 +68,14 @@ fn recursive_dit_fft_f32<S: Simd>(
     reals: &mut [f32],
     imags: &mut [f32],
     size: usize,
-    planner: &PlannerDit32,
     opts: &Options,
-    mut stage_twiddle_idx: usize,
-) -> usize {
+) {
     let log_size = size.ilog2() as usize;
 
     if size <= L1_BLOCK_SIZE {
         for stage in 0..log_size {
-            stage_twiddle_idx = execute_dit_stage_f32(
-                simd,
-                &mut reals[..size],
-                &mut imags[..size],
-                stage,
-                planner,
-                stage_twiddle_idx,
-            );
+            execute_dit_stage_f32(simd, &mut reals[..size], &mut imags[..size], stage);
         }
-        stage_twiddle_idx
     } else {
         let half = size / 2;
         let log_half = half.ilog2() as usize;
@@ -118,105 +85,60 @@ fn recursive_dit_fft_f32<S: Simd>(
         // Recursively process both halves
         run_maybe_in_parallel(
             size > opts.smallest_parallel_chunk_size,
-            || recursive_dit_fft_f32(simd, re_first_half, im_first_half, half, planner, opts, 0),
-            || recursive_dit_fft_f32(simd, re_second_half, im_second_half, half, planner, opts, 0),
+            || recursive_dit_fft_f32(simd, re_first_half, im_first_half, half, opts),
+            || recursive_dit_fft_f32(simd, re_second_half, im_second_half, half, opts),
         );
-
-        // Both halves completed stages 0..log_half-1
-        // Stages 0-5 use hardcoded twiddles, 6+ use planner
-        stage_twiddle_idx = log_half.saturating_sub(6);
 
         // Process remaining stages that span both halves
         for stage in log_half..log_size {
-            stage_twiddle_idx = execute_dit_stage_f32(
-                simd,
-                &mut reals[..size],
-                &mut imags[..size],
-                stage,
-                planner,
-                stage_twiddle_idx,
-            );
+            execute_dit_stage_f32(simd, &mut reals[..size], &mut imags[..size], stage);
         }
-
-        stage_twiddle_idx
     }
 }
 
 /// Execute a single DIT stage, dispatching to appropriate kernel based on chunk size.
-/// Returns updated stage_twiddle_idx.
-fn execute_dit_stage_f64<S: Simd>(
-    simd: S,
-    reals: &mut [f64],
-    imags: &mut [f64],
-    stage: usize,
-    planner: &PlannerDit64,
-    stage_twiddle_idx: usize,
-) -> usize {
+fn execute_dit_stage_f64<S: Simd>(simd: S, reals: &mut [f64], imags: &mut [f64], stage: usize) {
     let dist = 1 << stage; // 2.pow(stage)
     let chunk_size = dist * 2;
 
     if chunk_size == 2 {
         simd.vectorize(|| fft_dit_chunk_2(simd, reals, imags));
-        stage_twiddle_idx
     } else if chunk_size == 4 {
         fft_dit_chunk_4_f64(simd, reals, imags);
-        stage_twiddle_idx
     } else if chunk_size == 8 {
         fft_dit_chunk_8_f64(simd, reals, imags);
-        stage_twiddle_idx
     } else if chunk_size == 16 {
         fft_dit_chunk_16_f64(simd, reals, imags);
-        stage_twiddle_idx
     } else if chunk_size == 32 {
         fft_dit_chunk_32_f64(simd, reals, imags);
-        stage_twiddle_idx
     } else if chunk_size == 64 {
         fft_dit_chunk_64_f64(simd, reals, imags);
-        stage_twiddle_idx
     } else {
-        // For larger chunks, use general kernel with twiddles from planner
-        let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
-        fft_dit_chunk_n_f64(simd, reals, imags, twiddles_re, twiddles_im, dist);
-        stage_twiddle_idx + 1
+        // For larger chunks, generate twiddles on the fly
+        fft_dit_chunk_n_f64(simd, reals, imags, chunk_size, dist);
     }
 }
 
 /// Execute a single DIT stage, dispatching to appropriate kernel based on chunk size.
-/// Returns updated stage_twiddle_idx.
-fn execute_dit_stage_f32<S: Simd>(
-    simd: S,
-    reals: &mut [f32],
-    imags: &mut [f32],
-    stage: usize,
-    planner: &PlannerDit32,
-    stage_twiddle_idx: usize,
-) -> usize {
+fn execute_dit_stage_f32<S: Simd>(simd: S, reals: &mut [f32], imags: &mut [f32], stage: usize) {
     let dist = 1 << stage; // 2.pow(stage)
     let chunk_size = dist * 2;
 
     if chunk_size == 2 {
         simd.vectorize(|| fft_dit_chunk_2(simd, reals, imags));
-        stage_twiddle_idx
     } else if chunk_size == 4 {
         fft_dit_chunk_4_f32(simd, reals, imags);
-        stage_twiddle_idx
     } else if chunk_size == 8 {
         fft_dit_chunk_8_f32(simd, reals, imags);
-        stage_twiddle_idx
     } else if chunk_size == 16 {
         fft_dit_chunk_16_f32(simd, reals, imags);
-        stage_twiddle_idx
     } else if chunk_size == 32 {
         fft_dit_chunk_32_f32(simd, reals, imags);
-        stage_twiddle_idx
     } else if chunk_size == 64 {
         fft_dit_chunk_64_f32(simd, reals, imags);
-        stage_twiddle_idx
     } else {
-        // For larger chunks, use general kernel with twiddles from planner
-        let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
-        fft_dit_chunk_n_f32(simd, reals, imags, twiddles_re, twiddles_im, dist);
-        stage_twiddle_idx + 1
+        // For larger chunks, generate twiddles on the fly
+        fft_dit_chunk_n_f32(simd, reals, imags, chunk_size, dist);
     }
 }
 
@@ -290,7 +212,7 @@ fn fft_64_dit_with_planner_and_opts_impl<S: Simd>(
 
     simd.vectorize(
         #[inline(always)]
-        || recursive_dit_fft_f64(simd, reals, imags, n, planner, opts, 0),
+        || recursive_dit_fft_f64(simd, reals, imags, n, opts),
     );
 
     // Scaling for inverse transform
@@ -358,7 +280,7 @@ fn fft_32_dit_with_planner_and_opts_impl<S: Simd>(
 
     simd.vectorize(
         #[inline(always)]
-        || recursive_dit_fft_f32(simd, reals, imags, n, planner, opts, 0),
+        || recursive_dit_fft_f32(simd, reals, imags, n, opts),
     );
 
     // Scaling for inverse transform

--- a/src/kernels/dit.rs
+++ b/src/kernels/dit.rs
@@ -986,10 +986,10 @@ pub fn fft_dit_chunk_n_f64<S: Simd>(
 
 /// General DIT butterfly for f64
 ///
-/// Generates twiddle factors on the fly using the arbitrary-offset approach:
-/// Pre-computes a base chunk of LANES twiddles [W^0, W^1, ..., W^{LANES-1}],
-/// then for each group at offset k, computes the scalar anchor W^k via sin_cos
-/// and multiplies it by the base chunk.
+/// Generates twiddle factors on the fly using a streaming SIMD approach:
+/// Maintains a SIMD vector of LANES twiddles and advances it each iteration
+/// by multiplying with a scalar step factor W^LANES (pure arithmetic, no sin_cos).
+/// To prevent floating-point drift, re-seeds from sin_cos every RESEED iterations.
 #[inline(always)] // required by fearless_simd
 fn fft_dit_chunk_n_simd_f64<S: Simd>(
     simd: S,
@@ -999,6 +999,7 @@ fn fft_dit_chunk_n_simd_f64<S: Simd>(
     dist: usize,
 ) {
     const LANES: usize = 8;
+    const RESEED: usize = 1024;
     let chunk_size = dist * 2;
     assert_eq!(chunk_size, num_points);
     assert!(chunk_size >= LANES * 2);
@@ -1017,6 +1018,12 @@ fn fft_dit_chunk_n_simd_f64<S: Simd>(
     let base_re_v = f64x8::simd_from(simd, base_re);
     let base_im_v = f64x8::simd_from(simd, base_im);
 
+    // Streaming step factor: W^LANES as a scalar, splatted for SIMD multiply
+    let step_angle = theta * LANES as f64;
+    let (step_s, step_c) = step_angle.sin_cos();
+    let step_re = f64x8::splat(simd, step_c);
+    let step_im = f64x8::splat(simd, step_s);
+
     // The structure of outer for loop with inner for_each is intentional: on x86
     // fearless_simd needs inlining all the way down to intrinsics to work properly,
     // and using for_each in the outer scope would require a call to for_each function
@@ -1031,6 +1038,10 @@ fn fft_dit_chunk_n_simd_f64<S: Simd>(
         let (reals_s0, reals_s1) = reals_chunk.split_at_mut(dist);
         let (imags_s0, imags_s1) = imags_chunk.split_at_mut(dist);
 
+        // Initialize streaming twiddle state to base chunk (anchor = W^0 = 1)
+        let mut tw_re = base_re_v;
+        let mut tw_im = base_im_v;
+
         (reals_s0.as_chunks_mut::<LANES>().0.iter_mut())
             .zip(reals_s1.as_chunks_mut::<LANES>().0.iter_mut())
             .zip(imags_s0.as_chunks_mut::<LANES>().0.iter_mut())
@@ -1038,21 +1049,22 @@ fn fft_dit_chunk_n_simd_f64<S: Simd>(
             .enumerate()
             .for_each(|(lane_idx, (((re_s0, re_s1), im_s0), im_s1))| {
                 let two = f64x8::splat(simd, 2.0);
+
+                // Re-seed from sin_cos every RESEED iterations to combat drift
+                if lane_idx % RESEED == 0 && lane_idx > 0 {
+                    let offset = lane_idx * LANES;
+                    let start_angle = theta * offset as f64;
+                    let (s_start, c_start) = start_angle.sin_cos();
+                    let anchor_re = f64x8::splat(simd, c_start);
+                    let anchor_im = f64x8::splat(simd, s_start);
+                    tw_re = anchor_im.mul_add(-base_im_v, anchor_re * base_re_v);
+                    tw_im = anchor_im.mul_add(base_re_v, anchor_re * base_im_v);
+                }
+
                 let in0_re = f64x8::simd_from(simd, *re_s0);
                 let in1_re = f64x8::simd_from(simd, *re_s1);
                 let in0_im = f64x8::simd_from(simd, *im_s0);
                 let in1_im = f64x8::simd_from(simd, *im_s1);
-
-                // Compute twiddles on the fly: anchor W^k, then chunk = anchor * base
-                let offset = lane_idx * LANES;
-                let start_angle = theta * offset as f64;
-                let (s_start, c_start) = start_angle.sin_cos();
-                let anchor_re = f64x8::splat(simd, c_start);
-                let anchor_im = f64x8::splat(simd, s_start);
-
-                // Complex multiply: (anchor_re + i*anchor_im) * (base_re + i*base_im)
-                let tw_re = anchor_im.mul_add(-base_im_v, anchor_re * base_re_v);
-                let tw_im = anchor_im.mul_add(base_re_v, anchor_re * base_im_v);
 
                 // out0.re = (in0.re + tw_re * in1.re) - tw_im * in1.im
                 let out0_re = tw_im.mul_add(-in1_im, tw_re.mul_add(in1_re, in0_re));
@@ -1067,6 +1079,11 @@ fn fft_dit_chunk_n_simd_f64<S: Simd>(
                 out0_im.store_slice(im_s0);
                 out1_re.store_slice(re_s1);
                 out1_im.store_slice(im_s1);
+
+                // Advance streaming twiddles: multiply by W^LANES
+                let prev_re = tw_re;
+                tw_re = step_im.mul_add(-tw_im, step_re * prev_re);
+                tw_im = step_im.mul_add(prev_re, step_re * tw_im);
             });
     }
 }
@@ -1091,7 +1108,7 @@ pub fn fft_dit_chunk_n_f32<S: Simd>(
 
 /// General DIT butterfly for f32
 ///
-/// Generates twiddle factors on the fly using the arbitrary-offset approach.
+/// Generates twiddle factors on the fly using a streaming SIMD approach.
 /// See `fft_dit_chunk_n_simd_f64` for detailed explanation.
 #[inline(always)] // required by fearless_simd
 fn fft_dit_chunk_n_simd_f32<S: Simd>(
@@ -1102,11 +1119,12 @@ fn fft_dit_chunk_n_simd_f32<S: Simd>(
     dist: usize,
 ) {
     const LANES: usize = 16;
+    const RESEED: usize = 1024;
     let chunk_size = dist * 2;
     assert_eq!(chunk_size, num_points);
     assert!(chunk_size >= LANES * 2);
 
-    // Compute base twiddles in f64 for precision, then convert to f32
+    // Compute base twiddles and step factor in f64 for precision, then convert to f32
     let theta_f64 = -2.0 * std::f64::consts::PI / num_points as f64;
 
     // Pre-compute base twiddle chunk: W^0, W^1, ..., W^{LANES-1}
@@ -1121,6 +1139,12 @@ fn fft_dit_chunk_n_simd_f32<S: Simd>(
     let base_re_v = f32x16::simd_from(simd, base_re);
     let base_im_v = f32x16::simd_from(simd, base_im);
 
+    // Streaming step factor: W^LANES as a scalar, splatted for SIMD multiply
+    let step_angle = theta_f64 * LANES as f64;
+    let (step_s, step_c) = step_angle.sin_cos();
+    let step_re = f32x16::splat(simd, step_c as f32);
+    let step_im = f32x16::splat(simd, step_s as f32);
+
     // see fft_dit_chunk_n_simd_f64 for an explanation of this structure
     for (reals_chunk, imags_chunk) in reals
         .chunks_exact_mut(chunk_size)
@@ -1129,6 +1153,10 @@ fn fft_dit_chunk_n_simd_f32<S: Simd>(
         let (reals_s0, reals_s1) = reals_chunk.split_at_mut(dist);
         let (imags_s0, imags_s1) = imags_chunk.split_at_mut(dist);
 
+        // Initialize streaming twiddle state to base chunk (anchor = W^0 = 1)
+        let mut tw_re = base_re_v;
+        let mut tw_im = base_im_v;
+
         (reals_s0.as_chunks_mut::<LANES>().0.iter_mut())
             .zip(reals_s1.as_chunks_mut::<LANES>().0.iter_mut())
             .zip(imags_s0.as_chunks_mut::<LANES>().0.iter_mut())
@@ -1136,21 +1164,22 @@ fn fft_dit_chunk_n_simd_f32<S: Simd>(
             .enumerate()
             .for_each(|(lane_idx, (((re_s0, re_s1), im_s0), im_s1))| {
                 let two = f32x16::splat(simd, 2.0);
+
+                // Re-seed from sin_cos every RESEED iterations to combat drift
+                if lane_idx % RESEED == 0 && lane_idx > 0 {
+                    let offset = lane_idx * LANES;
+                    let start_angle = theta_f64 * offset as f64;
+                    let (s_start, c_start) = start_angle.sin_cos();
+                    let anchor_re = f32x16::splat(simd, c_start as f32);
+                    let anchor_im = f32x16::splat(simd, s_start as f32);
+                    tw_re = anchor_im.mul_add(-base_im_v, anchor_re * base_re_v);
+                    tw_im = anchor_im.mul_add(base_re_v, anchor_re * base_im_v);
+                }
+
                 let in0_re = f32x16::simd_from(simd, *re_s0);
                 let in1_re = f32x16::simd_from(simd, *re_s1);
                 let in0_im = f32x16::simd_from(simd, *im_s0);
                 let in1_im = f32x16::simd_from(simd, *im_s1);
-
-                // Compute twiddles on the fly: anchor W^k, then chunk = anchor * base
-                let offset = lane_idx * LANES;
-                let start_angle = theta_f64 * offset as f64;
-                let (s_start, c_start) = start_angle.sin_cos();
-                let anchor_re = f32x16::splat(simd, c_start as f32);
-                let anchor_im = f32x16::splat(simd, s_start as f32);
-
-                // Complex multiply: (anchor_re + i*anchor_im) * (base_re + i*base_im)
-                let tw_re = anchor_im.mul_add(-base_im_v, anchor_re * base_re_v);
-                let tw_im = anchor_im.mul_add(base_re_v, anchor_re * base_im_v);
 
                 // out0.re = (in0.re + tw_re * in1.re) - tw_im * in1.im
                 let out0_re = tw_im.mul_add(-in1_im, tw_re.mul_add(in1_re, in0_re));
@@ -1165,6 +1194,11 @@ fn fft_dit_chunk_n_simd_f32<S: Simd>(
                 out0_im.store_slice(im_s0);
                 out1_re.store_slice(re_s1);
                 out1_im.store_slice(im_s1);
+
+                // Advance streaming twiddles: multiply by W^LANES
+                let prev_re = tw_re;
+                tw_re = step_im.mul_add(-tw_im, step_re * prev_re);
+                tw_im = step_im.mul_add(prev_re, step_re * tw_im);
             });
     }
 }

--- a/src/kernels/dit.rs
+++ b/src/kernels/dit.rs
@@ -1051,8 +1051,8 @@ fn fft_dit_chunk_n_simd_f64<S: Simd>(
                 let anchor_im = f64x8::splat(simd, s_start);
 
                 // Complex multiply: (anchor_re + i*anchor_im) * (base_re + i*base_im)
-                let tw_re = anchor_re * base_re_v - anchor_im * base_im_v;
-                let tw_im = anchor_re * base_im_v + anchor_im * base_re_v;
+                let tw_re = anchor_im.mul_add(-base_im_v, anchor_re * base_re_v);
+                let tw_im = anchor_im.mul_add(base_re_v, anchor_re * base_im_v);
 
                 // out0.re = (in0.re + tw_re * in1.re) - tw_im * in1.im
                 let out0_re = tw_im.mul_add(-in1_im, tw_re.mul_add(in1_re, in0_re));
@@ -1149,8 +1149,8 @@ fn fft_dit_chunk_n_simd_f32<S: Simd>(
                 let anchor_im = f32x16::splat(simd, s_start as f32);
 
                 // Complex multiply: (anchor_re + i*anchor_im) * (base_re + i*base_im)
-                let tw_re = anchor_re * base_re_v - anchor_im * base_im_v;
-                let tw_im = anchor_re * base_im_v + anchor_im * base_re_v;
+                let tw_re = anchor_im.mul_add(-base_im_v, anchor_re * base_re_v);
+                let tw_im = anchor_im.mul_add(base_re_v, anchor_re * base_im_v);
 
                 // out0.re = (in0.re + tw_re * in1.re) - tw_im * in1.im
                 let out0_re = tw_im.mul_add(-in1_im, tw_re.mul_add(in1_re, in0_re));

--- a/src/kernels/dit.rs
+++ b/src/kernels/dit.rs
@@ -967,34 +967,55 @@ fn fft_dit_chunk_64_simd_f32<S: Simd>(simd: S, reals: &mut [f32], imags: &mut [f
 }
 
 /// General DIT butterfly for f64
+///
+/// Generates twiddle factors on the fly using the arbitrary-offset approach.
+/// `num_points` is the number of roots of unity for this stage (i.e. chunk_size = dist * 2).
 #[inline(never)] // otherwise every kernel gets inlined into the parent
 pub fn fft_dit_chunk_n_f64<S: Simd>(
     simd: S,
     reals: &mut [f64],
     imags: &mut [f64],
-    twiddles_re: &[f64],
-    twiddles_im: &[f64],
+    num_points: usize,
     dist: usize,
 ) {
     simd.vectorize(
         #[inline(always)]
-        || fft_dit_chunk_n_simd_f64(simd, reals, imags, twiddles_re, twiddles_im, dist),
+        || fft_dit_chunk_n_simd_f64(simd, reals, imags, num_points, dist),
     )
 }
 
 /// General DIT butterfly for f64
+///
+/// Generates twiddle factors on the fly using the arbitrary-offset approach:
+/// Pre-computes a base chunk of LANES twiddles [W^0, W^1, ..., W^{LANES-1}],
+/// then for each group at offset k, computes the scalar anchor W^k via sin_cos
+/// and multiplies it by the base chunk.
 #[inline(always)] // required by fearless_simd
 fn fft_dit_chunk_n_simd_f64<S: Simd>(
     simd: S,
     reals: &mut [f64],
     imags: &mut [f64],
-    twiddles_re: &[f64],
-    twiddles_im: &[f64],
+    num_points: usize,
     dist: usize,
 ) {
     const LANES: usize = 8;
     let chunk_size = dist * 2;
+    assert_eq!(chunk_size, num_points);
     assert!(chunk_size >= LANES * 2);
+
+    let theta = -2.0 * std::f64::consts::PI / num_points as f64;
+
+    // Pre-compute base twiddle chunk: W^0, W^1, ..., W^{LANES-1}
+    let mut base_re = [0.0_f64; LANES];
+    let mut base_im = [0.0_f64; LANES];
+    for i in 0..LANES {
+        let angle = theta * i as f64;
+        let (s, c) = angle.sin_cos();
+        base_re[i] = c;
+        base_im[i] = s;
+    }
+    let base_re_v = f64x8::simd_from(simd, base_re);
+    let base_im_v = f64x8::simd_from(simd, base_im);
 
     // The structure of outer for loop with inner for_each is intentional: on x86
     // fearless_simd needs inlining all the way down to intrinsics to work properly,
@@ -1014,17 +1035,24 @@ fn fft_dit_chunk_n_simd_f64<S: Simd>(
             .zip(reals_s1.as_chunks_mut::<LANES>().0.iter_mut())
             .zip(imags_s0.as_chunks_mut::<LANES>().0.iter_mut())
             .zip(imags_s1.as_chunks_mut::<LANES>().0.iter_mut())
-            .zip(twiddles_re.as_chunks::<LANES>().0.iter())
-            .zip(twiddles_im.as_chunks::<LANES>().0.iter())
-            .for_each(|(((((re_s0, re_s1), im_s0), im_s1), tw_re), tw_im)| {
+            .enumerate()
+            .for_each(|(lane_idx, (((re_s0, re_s1), im_s0), im_s1))| {
                 let two = f64x8::splat(simd, 2.0);
                 let in0_re = f64x8::simd_from(simd, *re_s0);
                 let in1_re = f64x8::simd_from(simd, *re_s1);
                 let in0_im = f64x8::simd_from(simd, *im_s0);
                 let in1_im = f64x8::simd_from(simd, *im_s1);
 
-                let tw_re = f64x8::simd_from(simd, *tw_re);
-                let tw_im = f64x8::simd_from(simd, *tw_im);
+                // Compute twiddles on the fly: anchor W^k, then chunk = anchor * base
+                let offset = lane_idx * LANES;
+                let start_angle = theta * offset as f64;
+                let (s_start, c_start) = start_angle.sin_cos();
+                let anchor_re = f64x8::splat(simd, c_start);
+                let anchor_im = f64x8::splat(simd, s_start);
+
+                // Complex multiply: (anchor_re + i*anchor_im) * (base_re + i*base_im)
+                let tw_re = anchor_re * base_re_v - anchor_im * base_im_v;
+                let tw_im = anchor_re * base_im_v + anchor_im * base_re_v;
 
                 // out0.re = (in0.re + tw_re * in1.re) - tw_im * in1.im
                 let out0_re = tw_im.mul_add(-in1_im, tw_re.mul_add(in1_re, in0_re));
@@ -1044,34 +1072,54 @@ fn fft_dit_chunk_n_simd_f64<S: Simd>(
 }
 
 /// General DIT butterfly for f32
+///
+/// Generates twiddle factors on the fly using the arbitrary-offset approach.
+/// `num_points` is the number of roots of unity for this stage (i.e. chunk_size = dist * 2).
 #[inline(never)] // otherwise every kernel gets inlined into the parent
 pub fn fft_dit_chunk_n_f32<S: Simd>(
     simd: S,
     reals: &mut [f32],
     imags: &mut [f32],
-    twiddles_re: &[f32],
-    twiddles_im: &[f32],
+    num_points: usize,
     dist: usize,
 ) {
     simd.vectorize(
         #[inline(always)]
-        || fft_dit_chunk_n_simd_f32(simd, reals, imags, twiddles_re, twiddles_im, dist),
+        || fft_dit_chunk_n_simd_f32(simd, reals, imags, num_points, dist),
     )
 }
 
 /// General DIT butterfly for f32
+///
+/// Generates twiddle factors on the fly using the arbitrary-offset approach.
+/// See `fft_dit_chunk_n_simd_f64` for detailed explanation.
 #[inline(always)] // required by fearless_simd
 fn fft_dit_chunk_n_simd_f32<S: Simd>(
     simd: S,
     reals: &mut [f32],
     imags: &mut [f32],
-    twiddles_re: &[f32],
-    twiddles_im: &[f32],
+    num_points: usize,
     dist: usize,
 ) {
     const LANES: usize = 16;
     let chunk_size = dist * 2;
+    assert_eq!(chunk_size, num_points);
     assert!(chunk_size >= LANES * 2);
+
+    // Compute base twiddles in f64 for precision, then convert to f32
+    let theta_f64 = -2.0 * std::f64::consts::PI / num_points as f64;
+
+    // Pre-compute base twiddle chunk: W^0, W^1, ..., W^{LANES-1}
+    let mut base_re = [0.0_f32; LANES];
+    let mut base_im = [0.0_f32; LANES];
+    for i in 0..LANES {
+        let angle = theta_f64 * i as f64;
+        let (s, c) = angle.sin_cos();
+        base_re[i] = c as f32;
+        base_im[i] = s as f32;
+    }
+    let base_re_v = f32x16::simd_from(simd, base_re);
+    let base_im_v = f32x16::simd_from(simd, base_im);
 
     // see fft_dit_chunk_n_simd_f64 for an explanation of this structure
     for (reals_chunk, imags_chunk) in reals
@@ -1085,17 +1133,24 @@ fn fft_dit_chunk_n_simd_f32<S: Simd>(
             .zip(reals_s1.as_chunks_mut::<LANES>().0.iter_mut())
             .zip(imags_s0.as_chunks_mut::<LANES>().0.iter_mut())
             .zip(imags_s1.as_chunks_mut::<LANES>().0.iter_mut())
-            .zip(twiddles_re.as_chunks::<LANES>().0.iter())
-            .zip(twiddles_im.as_chunks::<LANES>().0.iter())
-            .for_each(|(((((re_s0, re_s1), im_s0), im_s1), tw_re), tw_im)| {
+            .enumerate()
+            .for_each(|(lane_idx, (((re_s0, re_s1), im_s0), im_s1))| {
                 let two = f32x16::splat(simd, 2.0);
                 let in0_re = f32x16::simd_from(simd, *re_s0);
                 let in1_re = f32x16::simd_from(simd, *re_s1);
                 let in0_im = f32x16::simd_from(simd, *im_s0);
                 let in1_im = f32x16::simd_from(simd, *im_s1);
 
-                let tw_re = f32x16::simd_from(simd, *tw_re);
-                let tw_im = f32x16::simd_from(simd, *tw_im);
+                // Compute twiddles on the fly: anchor W^k, then chunk = anchor * base
+                let offset = lane_idx * LANES;
+                let start_angle = theta_f64 * offset as f64;
+                let (s_start, c_start) = start_angle.sin_cos();
+                let anchor_re = f32x16::splat(simd, c_start as f32);
+                let anchor_im = f32x16::splat(simd, s_start as f32);
+
+                // Complex multiply: (anchor_re + i*anchor_im) * (base_re + i*base_im)
+                let tw_re = anchor_re * base_re_v - anchor_im * base_im_v;
+                let tw_im = anchor_re * base_im_v + anchor_im * base_re_v;
 
                 // out0.re = (in0.re + tw_re * in1.re) - tw_im * in1.im
                 let out0_re = tw_im.mul_add(-in1_im, tw_re.mul_add(in1_re, in0_re));

--- a/src/kernels/dit.rs
+++ b/src/kernels/dit.rs
@@ -1042,49 +1042,50 @@ fn fft_dit_chunk_n_simd_f64<S: Simd>(
         let mut tw_re = base_re_v;
         let mut tw_im = base_im_v;
 
-        (reals_s0.as_chunks_mut::<LANES>().0.iter_mut())
-            .zip(reals_s1.as_chunks_mut::<LANES>().0.iter_mut())
-            .zip(imags_s0.as_chunks_mut::<LANES>().0.iter_mut())
-            .zip(imags_s1.as_chunks_mut::<LANES>().0.iter_mut())
-            .enumerate()
-            .for_each(|(lane_idx, (((re_s0, re_s1), im_s0), im_s1))| {
-                let two = f64x8::splat(simd, 2.0);
+        for (lane_idx, (((re_s0, re_s1), im_s0), im_s1)) in
+            (reals_s0.as_chunks_mut::<LANES>().0.iter_mut())
+                .zip(reals_s1.as_chunks_mut::<LANES>().0.iter_mut())
+                .zip(imags_s0.as_chunks_mut::<LANES>().0.iter_mut())
+                .zip(imags_s1.as_chunks_mut::<LANES>().0.iter_mut())
+                .enumerate()
+        {
+            let two = f64x8::splat(simd, 2.0);
 
-                // Re-seed from sin_cos every RESEED iterations to combat drift
-                if lane_idx % RESEED == 0 && lane_idx > 0 {
-                    let offset = lane_idx * LANES;
-                    let start_angle = theta * offset as f64;
-                    let (s_start, c_start) = start_angle.sin_cos();
-                    let anchor_re = f64x8::splat(simd, c_start);
-                    let anchor_im = f64x8::splat(simd, s_start);
-                    tw_re = anchor_im.mul_add(-base_im_v, anchor_re * base_re_v);
-                    tw_im = anchor_im.mul_add(base_re_v, anchor_re * base_im_v);
-                }
+            // Re-seed from sin_cos every RESEED iterations to combat drift
+            if lane_idx % RESEED == 0 && lane_idx > 0 {
+                let offset = lane_idx * LANES;
+                let start_angle = theta * offset as f64;
+                let (s_start, c_start) = start_angle.sin_cos();
+                let anchor_re = f64x8::splat(simd, c_start);
+                let anchor_im = f64x8::splat(simd, s_start);
+                tw_re = anchor_im.mul_add(-base_im_v, anchor_re * base_re_v);
+                tw_im = anchor_im.mul_add(base_re_v, anchor_re * base_im_v);
+            }
 
-                let in0_re = f64x8::simd_from(simd, *re_s0);
-                let in1_re = f64x8::simd_from(simd, *re_s1);
-                let in0_im = f64x8::simd_from(simd, *im_s0);
-                let in1_im = f64x8::simd_from(simd, *im_s1);
+            let in0_re = f64x8::simd_from(simd, *re_s0);
+            let in1_re = f64x8::simd_from(simd, *re_s1);
+            let in0_im = f64x8::simd_from(simd, *im_s0);
+            let in1_im = f64x8::simd_from(simd, *im_s1);
 
-                // out0.re = (in0.re + tw_re * in1.re) - tw_im * in1.im
-                let out0_re = tw_im.mul_add(-in1_im, tw_re.mul_add(in1_re, in0_re));
-                // out0.im = (in0.im + tw_re * in1.im) + tw_im * in1.re
-                let out0_im = tw_im.mul_add(in1_re, tw_re.mul_add(in1_im, in0_im));
+            // out0.re = (in0.re + tw_re * in1.re) - tw_im * in1.im
+            let out0_re = tw_im.mul_add(-in1_im, tw_re.mul_add(in1_re, in0_re));
+            // out0.im = (in0.im + tw_re * in1.im) + tw_im * in1.re
+            let out0_im = tw_im.mul_add(in1_re, tw_re.mul_add(in1_im, in0_im));
 
-                // Use FMA for out1 = 2*in0 - out0
-                let out1_re = two.mul_sub(in0_re, out0_re);
-                let out1_im = two.mul_sub(in0_im, out0_im);
+            // Use FMA for out1 = 2*in0 - out0
+            let out1_re = two.mul_sub(in0_re, out0_re);
+            let out1_im = two.mul_sub(in0_im, out0_im);
 
-                out0_re.store_slice(re_s0);
-                out0_im.store_slice(im_s0);
-                out1_re.store_slice(re_s1);
-                out1_im.store_slice(im_s1);
+            out0_re.store_slice(re_s0);
+            out0_im.store_slice(im_s0);
+            out1_re.store_slice(re_s1);
+            out1_im.store_slice(im_s1);
 
-                // Advance streaming twiddles: multiply by W^LANES
-                let prev_re = tw_re;
-                tw_re = step_im.mul_add(-tw_im, step_re * prev_re);
-                tw_im = step_im.mul_add(prev_re, step_re * tw_im);
-            });
+            // Advance streaming twiddles: multiply by W^LANES
+            let prev_re = tw_re;
+            tw_re = step_im.mul_add(-tw_im, step_re * prev_re);
+            tw_im = step_im.mul_add(prev_re, step_re * tw_im);
+        }
     }
 }
 
@@ -1157,48 +1158,49 @@ fn fft_dit_chunk_n_simd_f32<S: Simd>(
         let mut tw_re = base_re_v;
         let mut tw_im = base_im_v;
 
-        (reals_s0.as_chunks_mut::<LANES>().0.iter_mut())
-            .zip(reals_s1.as_chunks_mut::<LANES>().0.iter_mut())
-            .zip(imags_s0.as_chunks_mut::<LANES>().0.iter_mut())
-            .zip(imags_s1.as_chunks_mut::<LANES>().0.iter_mut())
-            .enumerate()
-            .for_each(|(lane_idx, (((re_s0, re_s1), im_s0), im_s1))| {
-                let two = f32x16::splat(simd, 2.0);
+        for (lane_idx, (((re_s0, re_s1), im_s0), im_s1)) in
+            (reals_s0.as_chunks_mut::<LANES>().0.iter_mut())
+                .zip(reals_s1.as_chunks_mut::<LANES>().0.iter_mut())
+                .zip(imags_s0.as_chunks_mut::<LANES>().0.iter_mut())
+                .zip(imags_s1.as_chunks_mut::<LANES>().0.iter_mut())
+                .enumerate()
+        {
+            let two = f32x16::splat(simd, 2.0);
 
-                // Re-seed from sin_cos every RESEED iterations to combat drift
-                if lane_idx % RESEED == 0 && lane_idx > 0 {
-                    let offset = lane_idx * LANES;
-                    let start_angle = theta_f64 * offset as f64;
-                    let (s_start, c_start) = start_angle.sin_cos();
-                    let anchor_re = f32x16::splat(simd, c_start as f32);
-                    let anchor_im = f32x16::splat(simd, s_start as f32);
-                    tw_re = anchor_im.mul_add(-base_im_v, anchor_re * base_re_v);
-                    tw_im = anchor_im.mul_add(base_re_v, anchor_re * base_im_v);
-                }
+            // Re-seed from sin_cos every RESEED iterations to combat drift
+            if lane_idx % RESEED == 0 && lane_idx > 0 {
+                let offset = lane_idx * LANES;
+                let start_angle = theta_f64 * offset as f64;
+                let (s_start, c_start) = start_angle.sin_cos();
+                let anchor_re = f32x16::splat(simd, c_start as f32);
+                let anchor_im = f32x16::splat(simd, s_start as f32);
+                tw_re = anchor_im.mul_add(-base_im_v, anchor_re * base_re_v);
+                tw_im = anchor_im.mul_add(base_re_v, anchor_re * base_im_v);
+            }
 
-                let in0_re = f32x16::simd_from(simd, *re_s0);
-                let in1_re = f32x16::simd_from(simd, *re_s1);
-                let in0_im = f32x16::simd_from(simd, *im_s0);
-                let in1_im = f32x16::simd_from(simd, *im_s1);
+            let in0_re = f32x16::simd_from(simd, *re_s0);
+            let in1_re = f32x16::simd_from(simd, *re_s1);
+            let in0_im = f32x16::simd_from(simd, *im_s0);
+            let in1_im = f32x16::simd_from(simd, *im_s1);
 
-                // out0.re = (in0.re + tw_re * in1.re) - tw_im * in1.im
-                let out0_re = tw_im.mul_add(-in1_im, tw_re.mul_add(in1_re, in0_re));
-                // out0.im = (in0.im + tw_re * in1.im) + tw_im * in1.re
-                let out0_im = tw_im.mul_add(in1_re, tw_re.mul_add(in1_im, in0_im));
+            // out0.re = (in0.re + tw_re * in1.re) - tw_im * in1.im
+            let out0_re = tw_im.mul_add(-in1_im, tw_re.mul_add(in1_re, in0_re));
+            // out0.im = (in0.im + tw_re * in1.im) + tw_im * in1.re
+            let out0_im = tw_im.mul_add(in1_re, tw_re.mul_add(in1_im, in0_im));
 
-                // Use FMA for out1 = 2*in0 - out0
-                let out1_re = two.mul_sub(in0_re, out0_re);
-                let out1_im = two.mul_sub(in0_im, out0_im);
+            // Use FMA for out1 = 2*in0 - out0
+            let out1_re = two.mul_sub(in0_re, out0_re);
+            let out1_im = two.mul_sub(in0_im, out0_im);
 
-                out0_re.store_slice(re_s0);
-                out0_im.store_slice(im_s0);
-                out1_re.store_slice(re_s1);
-                out1_im.store_slice(im_s1);
+            out0_re.store_slice(re_s0);
+            out0_im.store_slice(im_s0);
+            out1_re.store_slice(re_s1);
+            out1_im.store_slice(im_s1);
 
-                // Advance streaming twiddles: multiply by W^LANES
-                let prev_re = tw_re;
-                tw_re = step_im.mul_add(-tw_im, step_re * prev_re);
-                tw_im = step_im.mul_add(prev_re, step_re * tw_im);
-            });
+            // Advance streaming twiddles: multiply by W^LANES
+            let prev_re = tw_re;
+            tw_re = step_im.mul_add(-tw_im, step_re * prev_re);
+            tw_im = step_im.mul_add(prev_re, step_re * tw_im);
+        }
     }
 }

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -15,11 +15,12 @@ pub enum Direction {
 
 macro_rules! impl_planner_dit_for {
     ($struct_name:ident, $precision:ident) => {
-        /// DIT-specific planner that pre-computes twiddles for all stages
+        /// DIT-specific planner
+        ///
+        /// Twiddle factors for stages with chunk_size > 64 are generated on the fly
+        /// by the kernels using the arbitrary-offset approach, so no pre-computation
+        /// is needed.
         pub struct $struct_name {
-            /// Twiddles for each stage that needs them (stages with chunk_size > 64)
-            /// Each element contains (twiddles_re, twiddles_im) for that stage
-            pub(crate) stage_twiddles: Vec<(Vec<$precision>, Vec<$precision>)>,
             /// The direction of the FFT
             pub(crate) direction: Direction,
             /// The log2 of the FFT size
@@ -34,34 +35,9 @@ macro_rules! impl_planner_dit_for {
                 assert!(num_points > 0 && num_points.is_power_of_two());
 
                 let simd_level = fearless_simd::Level::new();
-
                 let log_n = num_points.ilog2() as usize;
-                let mut stage_twiddles = Vec::new();
-
-                // Pre-compute twiddles for each stage that needs them
-                for stage in 0..log_n {
-                    let dist = 1 << stage; // 2.pow(stage)
-                    let chunk_size = dist * 2;
-
-                    // Only stages with chunk_size > 64 need twiddles (we have SIMD kernels up to 64)
-                    if chunk_size > 64 {
-                        let mut twiddles_re = vec![0.0 as $precision; dist];
-                        let mut twiddles_im = vec![0.0 as $precision; dist];
-
-                        let angle_mult =
-                            -2.0 * std::$precision::consts::PI / chunk_size as $precision;
-                        for k in 0..dist {
-                            let angle = angle_mult * k as $precision;
-                            twiddles_re[k] = angle.cos();
-                            twiddles_im[k] = angle.sin();
-                        }
-
-                        stage_twiddles.push((twiddles_re, twiddles_im));
-                    }
-                }
 
                 Self {
-                    stage_twiddles,
                     direction,
                     log_n,
                     simd_level,


### PR DESCRIPTION
Computes twiddles on the fly in the variable-size kernel instead of caching them.

This reduces memory usage since the twiddles no longer need to be stored. When combined with #95 we need no auxiliary memory at all for the entire FFT process, including interleaving/deinterleaving and bit reversal.

Zen4 results: on large sizes this is neutral on a single thread and a 12% improvement when multi-threaded. However, small sizes that are not memory-bound do take a large performance penalty, with up to 60% more time taken.

M4 seems to benefit from this on large sizes.

Detailed benchmarks:

Single threaded:

Zen4: https://gist.github.com/Shnatsel/55e32f567c6f1a99ee96f2713bc89b5a
M4: https://gist.github.com/Shnatsel/2695ba6fbc3263a2679f045db5546127

Multi-threaded:

Zen4: https://gist.github.com/Shnatsel/3db0fe24d59c7e4a9a923a1b47653ca0
M4: https://gist.github.com/Shnatsel/e03e1cd148e5208b15448d01223ed5a8

