### PR TITLE
PoC: Radix 2^2 + parallel kernel

### DIFF
--- a/src/algorithms/dit.rs
+++ b/src/algorithms/dit.rs
@@ -41,44 +41,70 @@ fn recursive_dit_fft_f64<S: Simd>(
     let log_size = size.ilog2() as usize;
 
     if size <= L1_BLOCK_SIZE {
-        for stage in 0..log_size {
-            stage_twiddle_idx = execute_dit_stage_f64(
+        let mut stage = 0;
+        while stage < log_size {
+            let (new_idx, consumed) = execute_dit_stages_f64(
                 simd,
                 &mut reals[..size],
                 &mut imags[..size],
                 stage,
+                log_size - stage,
                 planner,
                 stage_twiddle_idx,
             );
+            stage_twiddle_idx = new_idx;
+            stage += consumed;
         }
         stage_twiddle_idx
     } else {
-        let half = size / 2;
-        let log_half = half.ilog2() as usize;
+        let quarter = size / 4;
+        let log_quarter = quarter.ilog2() as usize;
 
-        let (re_first_half, re_second_half) = reals.split_at_mut(half);
-        let (im_first_half, im_second_half) = imags.split_at_mut(half);
-        // Recursively process both halves
+        let (re_lo, re_hi) = reals.split_at_mut(size / 2);
+        let (im_lo, im_hi) = imags.split_at_mut(size / 2);
+        let (re_q0, re_q1) = re_lo.split_at_mut(quarter);
+        let (im_q0, im_q1) = im_lo.split_at_mut(quarter);
+        let (re_q2, re_q3) = re_hi.split_at_mut(quarter);
+        let (im_q2, im_q3) = im_hi.split_at_mut(quarter);
+
+        // Recursively process all 4 quarters (parallel across pairs)
         run_maybe_in_parallel(
             size > opts.smallest_parallel_chunk_size,
-            || recursive_dit_fft_f64(simd, re_first_half, im_first_half, half, planner, opts, 0),
-            || recursive_dit_fft_f64(simd, re_second_half, im_second_half, half, planner, opts, 0),
+            || {
+                run_maybe_in_parallel(
+                    size / 2 > opts.smallest_parallel_chunk_size,
+                    || recursive_dit_fft_f64(simd, re_q0, im_q0, quarter, planner, opts, 0),
+                    || recursive_dit_fft_f64(simd, re_q1, im_q1, quarter, planner, opts, 0),
+                )
+            },
+            || {
+                run_maybe_in_parallel(
+                    size / 2 > opts.smallest_parallel_chunk_size,
+                    || recursive_dit_fft_f64(simd, re_q2, im_q2, quarter, planner, opts, 0),
+                    || recursive_dit_fft_f64(simd, re_q3, im_q3, quarter, planner, opts, 0),
+                )
+            },
         );
 
-        // Both halves completed stages 0..log_half-1
+        // All 4 quarters completed stages 0..log_quarter-1.
+        // Now process the 2 remaining cross-block stages (log_quarter and log_quarter+1)
+        // using the fused kernel.
         // Stages 0-5 use hardcoded twiddles, 6+ use planner
-        stage_twiddle_idx = log_half.saturating_sub(6);
+        stage_twiddle_idx = log_quarter.saturating_sub(6);
 
-        // Process remaining stages that span both halves
-        for stage in log_half..log_size {
-            stage_twiddle_idx = execute_dit_stage_f64(
+        let mut stage = log_quarter;
+        while stage < log_size {
+            let (new_idx, consumed) = execute_dit_stages_f64(
                 simd,
                 &mut reals[..size],
                 &mut imags[..size],
                 stage,
+                log_size - stage,
                 planner,
                 stage_twiddle_idx,
             );
+            stage_twiddle_idx = new_idx;
+            stage += consumed;
         }
 
         stage_twiddle_idx
@@ -142,42 +168,58 @@ fn recursive_dit_fft_f32<S: Simd>(
     }
 }
 
-/// Execute a single DIT stage, dispatching to appropriate kernel based on chunk size.
-/// Returns updated stage_twiddle_idx.
-fn execute_dit_stage_f64<S: Simd>(
+/// Execute one or two DIT stages, dispatching to appropriate kernel based on chunk size.
+/// Returns (updated stage_twiddle_idx, number of stages consumed).
+fn execute_dit_stages_f64<S: Simd>(
     simd: S,
     reals: &mut [f64],
     imags: &mut [f64],
     stage: usize,
+    stages_remaining: usize,
     planner: &PlannerDit64,
     stage_twiddle_idx: usize,
-) -> usize {
+) -> (usize, usize) {
     let dist = 1 << stage; // 2.pow(stage)
     let chunk_size = dist * 2;
 
     if chunk_size == 2 {
         simd.vectorize(|| fft_dit_chunk_2(simd, reals, imags));
-        stage_twiddle_idx
+        (stage_twiddle_idx, 1)
     } else if chunk_size == 4 {
         fft_dit_chunk_4_f64(simd, reals, imags);
-        stage_twiddle_idx
+        (stage_twiddle_idx, 1)
     } else if chunk_size == 8 {
         fft_dit_chunk_8_f64(simd, reals, imags);
-        stage_twiddle_idx
+        (stage_twiddle_idx, 1)
     } else if chunk_size == 16 {
         fft_dit_chunk_16_f64(simd, reals, imags);
-        stage_twiddle_idx
+        (stage_twiddle_idx, 1)
     } else if chunk_size == 32 {
         fft_dit_chunk_32_f64(simd, reals, imags);
-        stage_twiddle_idx
+        (stage_twiddle_idx, 1)
     } else if chunk_size == 64 {
         fft_dit_chunk_64_f64(simd, reals, imags);
-        stage_twiddle_idx
+        (stage_twiddle_idx, 1)
+    } else if stages_remaining >= 2 {
+        // Fuse two stages into a single pass over memory
+        let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
+        let (twiddles_re2, twiddles_im2) = &planner.stage_twiddles[stage_twiddle_idx + 1];
+        fft_dit_fused_2stage_f64_narrow(
+            simd,
+            reals,
+            imags,
+            twiddles_re,
+            twiddles_im,
+            twiddles_re2,
+            twiddles_im2,
+            dist,
+        );
+        (stage_twiddle_idx + 2, 2)
     } else {
-        // For larger chunks, use general kernel with twiddles from planner
+        // Last stage (odd number of stages remaining), use single-stage kernel
         let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
         fft_dit_chunk_n_f64(simd, reals, imags, twiddles_re, twiddles_im, dist);
-        stage_twiddle_idx + 1
+        (stage_twiddle_idx + 1, 1)
     }
 }
 

--- a/src/algorithms/dit.rs
+++ b/src/algorithms/dit.rs
@@ -37,6 +37,7 @@ fn recursive_dit_fft_f64<S: Simd>(
     planner: &PlannerDit64,
     opts: &Options,
     mut stage_twiddle_idx: usize,
+    is_top_level: bool,
 ) -> usize {
     let log_size = size.ilog2() as usize;
 
@@ -73,15 +74,15 @@ fn recursive_dit_fft_f64<S: Simd>(
             || {
                 run_maybe_in_parallel(
                     size / 2 > opts.smallest_parallel_chunk_size,
-                    || recursive_dit_fft_f64(simd, re_q0, im_q0, quarter, planner, opts, 0),
-                    || recursive_dit_fft_f64(simd, re_q1, im_q1, quarter, planner, opts, 0),
+                    || recursive_dit_fft_f64(simd, re_q0, im_q0, quarter, planner, opts, 0, false),
+                    || recursive_dit_fft_f64(simd, re_q1, im_q1, quarter, planner, opts, 0, false),
                 )
             },
             || {
                 run_maybe_in_parallel(
                     size / 2 > opts.smallest_parallel_chunk_size,
-                    || recursive_dit_fft_f64(simd, re_q2, im_q2, quarter, planner, opts, 0),
-                    || recursive_dit_fft_f64(simd, re_q3, im_q3, quarter, planner, opts, 0),
+                    || recursive_dit_fft_f64(simd, re_q2, im_q2, quarter, planner, opts, 0, false),
+                    || recursive_dit_fft_f64(simd, re_q3, im_q3, quarter, planner, opts, 0, false),
                 )
             },
         );
@@ -93,13 +94,39 @@ fn recursive_dit_fft_f64<S: Simd>(
         stage_twiddle_idx = log_quarter.saturating_sub(6);
 
         let mut stage = log_quarter;
+        let _ = is_top_level; // used only with "parallel" feature
         while stage < log_size {
+            let stages_remaining = log_size - stage;
+
+            // At the top level, the last fused 2-stage pass spans the entire array
+            // and cannot be parallelized through recursion, so use the parallel kernel.
+            #[cfg(feature = "parallel")]
+            if is_top_level && stages_remaining >= 2 && (1 << stage) * 2 > 64 {
+                let dist = 1 << stage;
+                let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
+                let (twiddles_re2, twiddles_im2) =
+                    &planner.stage_twiddles[stage_twiddle_idx + 1];
+                fft_dit_fused_2stage_f64_narrow_parallel(
+                    simd,
+                    &mut reals[..size],
+                    &mut imags[..size],
+                    twiddles_re,
+                    twiddles_im,
+                    twiddles_re2,
+                    twiddles_im2,
+                    dist,
+                );
+                stage_twiddle_idx += 2;
+                stage += 2;
+                continue;
+            }
+
             let (new_idx, consumed) = execute_dit_stages_f64(
                 simd,
                 &mut reals[..size],
                 &mut imags[..size],
                 stage,
-                log_size - stage,
+                stages_remaining,
                 planner,
                 stage_twiddle_idx,
             );
@@ -374,7 +401,7 @@ fn fft_64_dit_with_planner_and_opts_impl<S: Simd>(
 
     simd.vectorize(
         #[inline(always)]
-        || recursive_dit_fft_f64(simd, reals, imags, n, planner, opts, 0),
+        || recursive_dit_fft_f64(simd, reals, imags, n, planner, opts, 0, true),
     );
 
     // Scaling for inverse transform

--- a/src/algorithms/dit.rs
+++ b/src/algorithms/dit.rs
@@ -226,10 +226,10 @@ fn execute_dit_stages_f64<S: Simd>(
     } else if chunk_size == 64 {
         fft_dit_chunk_64_f64(simd, reals, imags);
         (stage_twiddle_idx, 1)
-    } else if cfg!(feature = "parallel") {
-        // When nearing the end, use the parallelized kernel because recursion doesn't parallelize enough
+    } else {
         #[cfg(feature = "parallel")]
         {
+            // When nearing the end, use the parallelized kernel because recursion doesn't parallelize enough
             // TODO: make this dynamic based on std::thread::available_parallelism(), maybe?
             // The jump from 16 threads to all threads is probably not very large so this is entering diminishing returns
             if stages_remaining > 4 {
@@ -267,31 +267,29 @@ fn execute_dit_stages_f64<S: Simd>(
                 fft_dit_chunk_n_f64(simd, reals, imags, twiddles_re, twiddles_im, dist);
                 (stage_twiddle_idx + 1, 1)
             }
-            #[cfg(not(feature = "parallel"))]
-            {
-                unreachable!()
-            }
         }
-    } else if stages_remaining >= 2 {
-        // Fuse two stages into a single pass over memory
-        let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
-        let (twiddles_re2, twiddles_im2) = &planner.stage_twiddles[stage_twiddle_idx + 1];
-        fft_dit_fused_2stage_f64_narrow(
-            simd,
-            reals,
-            imags,
-            twiddles_re,
-            twiddles_im,
-            twiddles_re2,
-            twiddles_im2,
-            dist,
-        );
-        (stage_twiddle_idx + 2, 2)
-    } else {
-        // Last stage (odd number of stages remaining), use single-stage kernel
-        let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
-        fft_dit_chunk_n_f64(simd, reals, imags, twiddles_re, twiddles_im, dist);
-        (stage_twiddle_idx + 1, 1)
+        #[cfg(not(feature = "parallel"))]
+        if stages_remaining >= 2 {
+            // Fuse two stages into a single pass over memory
+            let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
+            let (twiddles_re2, twiddles_im2) = &planner.stage_twiddles[stage_twiddle_idx + 1];
+            fft_dit_fused_2stage_f64_narrow(
+                simd,
+                reals,
+                imags,
+                twiddles_re,
+                twiddles_im,
+                twiddles_re2,
+                twiddles_im2,
+                dist,
+            );
+            (stage_twiddle_idx + 2, 2)
+        } else {
+            // Last stage (odd number of stages remaining), use single-stage kernel
+            let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
+            fft_dit_chunk_n_f64(simd, reals, imags, twiddles_re, twiddles_im, dist);
+            (stage_twiddle_idx + 1, 1)
+        }
     }
 }
 

--- a/src/algorithms/dit.rs
+++ b/src/algorithms/dit.rs
@@ -226,6 +226,51 @@ fn execute_dit_stages_f64<S: Simd>(
     } else if chunk_size == 64 {
         fft_dit_chunk_64_f64(simd, reals, imags);
         (stage_twiddle_idx, 1)
+    } else if cfg!(feature = "parallel") {
+        // When nearing the end, use the parallelized kernel because recursion doesn't parallelize enough
+        #[cfg(feature = "parallel")]
+        {
+            if stages_remaining >= 4 {
+                // TODO: make this dynamic based on std::thread::available_parallelism()
+                // Fuse two stages into a single pass over memory
+                let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
+                let (twiddles_re2, twiddles_im2) = &planner.stage_twiddles[stage_twiddle_idx + 1];
+                fft_dit_fused_2stage_f64_narrow(
+                    simd,
+                    reals,
+                    imags,
+                    twiddles_re,
+                    twiddles_im,
+                    twiddles_re2,
+                    twiddles_im2,
+                    dist,
+                );
+                (stage_twiddle_idx + 2, 2)
+            } else if stages_remaining >= 2 {
+                let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
+                let (twiddles_re2, twiddles_im2) = &planner.stage_twiddles[stage_twiddle_idx + 1];
+                fft_dit_fused_2stage_f64_narrow_parallel(
+                    simd,
+                    reals,
+                    imags,
+                    twiddles_re,
+                    twiddles_im,
+                    twiddles_re2,
+                    twiddles_im2,
+                    dist,
+                );
+                (stage_twiddle_idx + 2, 2)
+            } else {
+                // Last stage (odd number of stages remaining), use single-stage kernel
+                let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
+                fft_dit_chunk_n_f64(simd, reals, imags, twiddles_re, twiddles_im, dist);
+                (stage_twiddle_idx + 1, 1)
+            }
+            #[cfg(not(feature = "parallel"))]
+            {
+                unreachable!()
+            }
+        }
     } else if stages_remaining >= 2 {
         // Fuse two stages into a single pass over memory
         let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];

--- a/src/algorithms/dit.rs
+++ b/src/algorithms/dit.rs
@@ -22,7 +22,15 @@ use crate::options::Options;
 use crate::parallel::run_maybe_in_parallel;
 use crate::planner::{Direction, PlannerDit32, PlannerDit64};
 
-/// L1 cache block size in complex elements (8KB for f32, 16KB for f64)
+/// L1 cache block size in complex elements.
+///
+/// Each complex element uses 2 × size_of::<T>() bytes in split re/im format.
+/// For f32: 4096 × 4 bytes × 2 arrays = 32KB.
+/// For f64: 4096 × 8 bytes × 2 arrays = 64KB.
+///
+/// Must be small enough that the block + its twiddle factors fit comfortably in L1d.
+/// The twiddle factors for stages within the block accumulate to roughly block_size elements,
+/// so total L1 footprint is ~3× the data size.
 const L1_BLOCK_SIZE: usize = 1024;
 
 /// Run DIT stages from `start` to `end` (exclusive), fusing pairs of general

--- a/src/algorithms/dit.rs
+++ b/src/algorithms/dit.rs
@@ -22,66 +22,13 @@ use crate::options::Options;
 use crate::parallel::run_maybe_in_parallel;
 use crate::planner::{Direction, PlannerDit32, PlannerDit64};
 
-/// L1 cache block size in complex elements.
-///
-/// Each complex element uses 2 × size_of::<T>() bytes in split re/im format.
-/// For f32: 4096 × 4 bytes × 2 arrays = 32KB.
-/// For f64: 4096 × 8 bytes × 2 arrays = 64KB.
-///
-/// Must be small enough that the block + its twiddle factors fit comfortably in L1d.
-/// The twiddle factors for stages within the block accumulate to roughly block_size elements,
-/// so total L1 footprint is ~3× the data size.
+/// L1 cache block size in complex elements (8KB for f32, 16KB for f64)
 const L1_BLOCK_SIZE: usize = 1024;
-
-/// Run DIT stages from `start` to `end` (exclusive), fusing pairs of general
-/// stages into a single pass where possible (radix-2² optimization).
-/// Returns updated `stage_twiddle_idx`.
-fn run_dit_stages_f64<S: Simd>(
-    simd: S,
-    reals: &mut [f64],
-    imags: &mut [f64],
-    start: usize,
-    end: usize,
-    planner: &PlannerDit64,
-    mut stage_twiddle_idx: usize,
-) -> usize {
-    let mut stage = start;
-    while stage < end {
-        let dist = 1 << stage;
-        let chunk_size = dist * 2;
-
-        // Fuse two stages when both use general twiddles and there's a next stage
-        if chunk_size > 64 && stage + 1 < end {
-            let (tw_s_re, tw_s_im) = &planner.stage_twiddles[stage_twiddle_idx];
-            let (tw_s1_re, tw_s1_im) = &planner.stage_twiddles[stage_twiddle_idx + 1];
-            fft_dit_fused_2stage_f64_narrow(
-                simd,
-                reals,
-                imags,
-                tw_s_re,
-                tw_s_im,
-                &tw_s1_re[..dist],
-                &tw_s1_im[..dist],
-                dist,
-            );
-            stage_twiddle_idx += 2;
-            stage += 2;
-        } else {
-            stage_twiddle_idx =
-                execute_dit_stage_f64(simd, reals, imags, stage, planner, stage_twiddle_idx);
-            stage += 1;
-        }
-    }
-    stage_twiddle_idx
-}
 
 /// Recursive cache-blocked DIT FFT for f64 using post-order traversal.
 ///
 /// Recursively divides by 2 until reaching L1 cache size, processes stages within
 /// each block, then processes cross-block stages on return.
-///
-/// When the size is large enough to split into quarters, does so to produce
-/// two cross-block stages that can be fused by the radix-2² kernel.
 fn recursive_dit_fft_f64<S: Simd>(
     simd: S,
     reals: &mut [f64],
@@ -94,134 +41,51 @@ fn recursive_dit_fft_f64<S: Simd>(
     let log_size = size.ilog2() as usize;
 
     if size <= L1_BLOCK_SIZE {
-        run_dit_stages_f64(
-            simd,
-            &mut reals[..size],
-            &mut imags[..size],
-            0,
-            log_size,
-            planner,
-            stage_twiddle_idx,
-        )
-    } else if size >= L1_BLOCK_SIZE * 4 {
-        // Split into quarters: 4 sub-problems of size/4, then 2 cross-block stages.
-        // This gives the radix-2² fused kernel a pair of stages to work with.
-        let quarter = size / 4;
-        let log_quarter = quarter.ilog2() as usize;
-        let parallel = size > opts.smallest_parallel_chunk_size;
-
-        let (re_lo, re_hi) = reals.split_at_mut(size / 2);
-        let (im_lo, im_hi) = imags.split_at_mut(size / 2);
-        let (re_q0, re_q1) = re_lo.split_at_mut(quarter);
-        let (im_q0, im_q1) = im_lo.split_at_mut(quarter);
-        let (re_q2, re_q3) = re_hi.split_at_mut(quarter);
-        let (im_q2, im_q3) = im_hi.split_at_mut(quarter);
-
-        run_maybe_in_parallel(
-            parallel,
-            || {
-                run_maybe_in_parallel(
-                    parallel,
-                    || recursive_dit_fft_f64(simd, re_q0, im_q0, quarter, planner, opts, 0),
-                    || recursive_dit_fft_f64(simd, re_q1, im_q1, quarter, planner, opts, 0),
-                )
-            },
-            || {
-                run_maybe_in_parallel(
-                    parallel,
-                    || recursive_dit_fft_f64(simd, re_q2, im_q2, quarter, planner, opts, 0),
-                    || recursive_dit_fft_f64(simd, re_q3, im_q3, quarter, planner, opts, 0),
-                )
-            },
-        );
-
-        // All quarters completed stages 0..log_quarter-1.
-        // Now run 2 cross-block stages: log_quarter and log_quarter+1.
-        stage_twiddle_idx = log_quarter.saturating_sub(6);
-
-        run_dit_stages_f64(
-            simd,
-            &mut reals[..size],
-            &mut imags[..size],
-            log_quarter,
-            log_size,
-            planner,
-            stage_twiddle_idx,
-        )
+        for stage in 0..log_size {
+            stage_twiddle_idx = execute_dit_stage_f64(
+                simd,
+                &mut reals[..size],
+                &mut imags[..size],
+                stage,
+                planner,
+                stage_twiddle_idx,
+            );
+        }
+        stage_twiddle_idx
     } else {
-        // size is between L1_BLOCK_SIZE+1 and L1_BLOCK_SIZE*4-1
-        // Split into halves: 1 cross-block stage (cannot fuse, but these are small sizes)
         let half = size / 2;
         let log_half = half.ilog2() as usize;
 
         let (re_first_half, re_second_half) = reals.split_at_mut(half);
         let (im_first_half, im_second_half) = imags.split_at_mut(half);
+        // Recursively process both halves
         run_maybe_in_parallel(
             size > opts.smallest_parallel_chunk_size,
             || recursive_dit_fft_f64(simd, re_first_half, im_first_half, half, planner, opts, 0),
             || recursive_dit_fft_f64(simd, re_second_half, im_second_half, half, planner, opts, 0),
         );
 
+        // Both halves completed stages 0..log_half-1
+        // Stages 0-5 use hardcoded twiddles, 6+ use planner
         stage_twiddle_idx = log_half.saturating_sub(6);
 
-        run_dit_stages_f64(
-            simd,
-            &mut reals[..size],
-            &mut imags[..size],
-            log_half,
-            log_size,
-            planner,
-            stage_twiddle_idx,
-        )
-    }
-}
-
-/// Run DIT stages from `start` to `end` (exclusive), fusing pairs of general
-/// stages into a single pass where possible (radix-2² optimization).
-/// Returns updated `stage_twiddle_idx`.
-fn run_dit_stages_f32<S: Simd>(
-    simd: S,
-    reals: &mut [f32],
-    imags: &mut [f32],
-    start: usize,
-    end: usize,
-    planner: &PlannerDit32,
-    mut stage_twiddle_idx: usize,
-) -> usize {
-    let mut stage = start;
-    while stage < end {
-        let dist = 1 << stage;
-        let chunk_size = dist * 2;
-
-        // Fuse two stages when both use general twiddles and there's a next stage
-        if chunk_size > 64 && stage + 1 < end {
-            let (tw_s_re, tw_s_im) = &planner.stage_twiddles[stage_twiddle_idx];
-            let (tw_s1_re, tw_s1_im) = &planner.stage_twiddles[stage_twiddle_idx + 1];
-            fft_dit_fused_2stage_f32_narrow(
+        // Process remaining stages that span both halves
+        for stage in log_half..log_size {
+            stage_twiddle_idx = execute_dit_stage_f64(
                 simd,
-                reals,
-                imags,
-                tw_s_re,
-                tw_s_im,
-                &tw_s1_re[..dist],
-                &tw_s1_im[..dist],
-                dist,
+                &mut reals[..size],
+                &mut imags[..size],
+                stage,
+                planner,
+                stage_twiddle_idx,
             );
-            stage_twiddle_idx += 2;
-            stage += 2;
-        } else {
-            stage_twiddle_idx =
-                execute_dit_stage_f32(simd, reals, imags, stage, planner, stage_twiddle_idx);
-            stage += 1;
         }
+
+        stage_twiddle_idx
     }
-    stage_twiddle_idx
 }
 
 /// Recursive cache-blocked DIT FFT for f32 using post-order traversal.
-///
-/// When the size is large enough to split into quarters, does so to produce
-/// two cross-block stages that can be fused by the radix-2² kernel.
 fn recursive_dit_fft_f32<S: Simd>(
     simd: S,
     reals: &mut [f32],
@@ -234,83 +98,47 @@ fn recursive_dit_fft_f32<S: Simd>(
     let log_size = size.ilog2() as usize;
 
     if size <= L1_BLOCK_SIZE {
-        run_dit_stages_f32(
-            simd,
-            &mut reals[..size],
-            &mut imags[..size],
-            0,
-            log_size,
-            planner,
-            stage_twiddle_idx,
-        )
-    } else if size >= L1_BLOCK_SIZE * 4 {
-        // Split into quarters: 4 sub-problems of size/4, then 2 cross-block stages.
-        let quarter = size / 4;
-        let log_quarter = quarter.ilog2() as usize;
-        let parallel = size > opts.smallest_parallel_chunk_size;
-
-        let (re_lo, re_hi) = reals.split_at_mut(size / 2);
-        let (im_lo, im_hi) = imags.split_at_mut(size / 2);
-        let (re_q0, re_q1) = re_lo.split_at_mut(quarter);
-        let (im_q0, im_q1) = im_lo.split_at_mut(quarter);
-        let (re_q2, re_q3) = re_hi.split_at_mut(quarter);
-        let (im_q2, im_q3) = im_hi.split_at_mut(quarter);
-
-        run_maybe_in_parallel(
-            parallel,
-            || {
-                run_maybe_in_parallel(
-                    parallel,
-                    || recursive_dit_fft_f32(simd, re_q0, im_q0, quarter, planner, opts, 0),
-                    || recursive_dit_fft_f32(simd, re_q1, im_q1, quarter, planner, opts, 0),
-                )
-            },
-            || {
-                run_maybe_in_parallel(
-                    parallel,
-                    || recursive_dit_fft_f32(simd, re_q2, im_q2, quarter, planner, opts, 0),
-                    || recursive_dit_fft_f32(simd, re_q3, im_q3, quarter, planner, opts, 0),
-                )
-            },
-        );
-
-        // All quarters completed stages 0..log_quarter-1.
-        // Now run 2 cross-block stages: log_quarter and log_quarter+1.
-        stage_twiddle_idx = log_quarter.saturating_sub(6);
-
-        run_dit_stages_f32(
-            simd,
-            &mut reals[..size],
-            &mut imags[..size],
-            log_quarter,
-            log_size,
-            planner,
-            stage_twiddle_idx,
-        )
+        for stage in 0..log_size {
+            stage_twiddle_idx = execute_dit_stage_f32(
+                simd,
+                &mut reals[..size],
+                &mut imags[..size],
+                stage,
+                planner,
+                stage_twiddle_idx,
+            );
+        }
+        stage_twiddle_idx
     } else {
-        // size is between L1_BLOCK_SIZE+1 and L1_BLOCK_SIZE*4-1
         let half = size / 2;
         let log_half = half.ilog2() as usize;
 
         let (re_first_half, re_second_half) = reals.split_at_mut(half);
         let (im_first_half, im_second_half) = imags.split_at_mut(half);
+        // Recursively process both halves
         run_maybe_in_parallel(
             size > opts.smallest_parallel_chunk_size,
             || recursive_dit_fft_f32(simd, re_first_half, im_first_half, half, planner, opts, 0),
             || recursive_dit_fft_f32(simd, re_second_half, im_second_half, half, planner, opts, 0),
         );
 
+        // Both halves completed stages 0..log_half-1
+        // Stages 0-5 use hardcoded twiddles, 6+ use planner
         stage_twiddle_idx = log_half.saturating_sub(6);
 
-        run_dit_stages_f32(
-            simd,
-            &mut reals[..size],
-            &mut imags[..size],
-            log_half,
-            log_size,
-            planner,
-            stage_twiddle_idx,
-        )
+        // Process remaining stages that span both halves
+        for stage in log_half..log_size {
+            stage_twiddle_idx = execute_dit_stage_f32(
+                simd,
+                &mut reals[..size],
+                &mut imags[..size],
+                stage,
+                planner,
+                stage_twiddle_idx,
+            );
+        }
+
+        stage_twiddle_idx
     }
 }
 

--- a/src/algorithms/dit.rs
+++ b/src/algorithms/dit.rs
@@ -25,6 +25,48 @@ use crate::planner::{Direction, PlannerDit32, PlannerDit64};
 /// L1 cache block size in complex elements (8KB for f32, 16KB for f64)
 const L1_BLOCK_SIZE: usize = 1024;
 
+/// Run DIT stages from `start` to `end` (exclusive), fusing pairs of general
+/// stages into a single pass where possible (radix-2² optimization).
+/// Returns updated `stage_twiddle_idx`.
+fn run_dit_stages_f64<S: Simd>(
+    simd: S,
+    reals: &mut [f64],
+    imags: &mut [f64],
+    start: usize,
+    end: usize,
+    planner: &PlannerDit64,
+    mut stage_twiddle_idx: usize,
+) -> usize {
+    let mut stage = start;
+    while stage < end {
+        let dist = 1 << stage;
+        let chunk_size = dist * 2;
+
+        // Fuse two stages when both use general twiddles and there's a next stage
+        if chunk_size > 64 && stage + 1 < end {
+            let (tw_s_re, tw_s_im) = &planner.stage_twiddles[stage_twiddle_idx];
+            let (tw_s1_re, tw_s1_im) = &planner.stage_twiddles[stage_twiddle_idx + 1];
+            fft_dit_fused_2stage_f64_narrow(
+                simd,
+                reals,
+                imags,
+                tw_s_re,
+                tw_s_im,
+                &tw_s1_re[..dist],
+                &tw_s1_im[..dist],
+                dist,
+            );
+            stage_twiddle_idx += 2;
+            stage += 2;
+        } else {
+            stage_twiddle_idx =
+                execute_dit_stage_f64(simd, reals, imags, stage, planner, stage_twiddle_idx);
+            stage += 1;
+        }
+    }
+    stage_twiddle_idx
+}
+
 /// Recursive cache-blocked DIT FFT for f64 using post-order traversal.
 ///
 /// Recursively divides by 2 until reaching L1 cache size, processes stages within
@@ -41,17 +83,15 @@ fn recursive_dit_fft_f64<S: Simd>(
     let log_size = size.ilog2() as usize;
 
     if size <= L1_BLOCK_SIZE {
-        for stage in 0..log_size {
-            stage_twiddle_idx = execute_dit_stage_f64(
-                simd,
-                &mut reals[..size],
-                &mut imags[..size],
-                stage,
-                planner,
-                stage_twiddle_idx,
-            );
-        }
-        stage_twiddle_idx
+        run_dit_stages_f64(
+            simd,
+            &mut reals[..size],
+            &mut imags[..size],
+            0,
+            log_size,
+            planner,
+            stage_twiddle_idx,
+        )
     } else {
         let half = size / 2;
         let log_half = half.ilog2() as usize;
@@ -70,19 +110,58 @@ fn recursive_dit_fft_f64<S: Simd>(
         stage_twiddle_idx = log_half.saturating_sub(6);
 
         // Process remaining stages that span both halves
-        for stage in log_half..log_size {
-            stage_twiddle_idx = execute_dit_stage_f64(
-                simd,
-                &mut reals[..size],
-                &mut imags[..size],
-                stage,
-                planner,
-                stage_twiddle_idx,
-            );
-        }
-
-        stage_twiddle_idx
+        run_dit_stages_f64(
+            simd,
+            &mut reals[..size],
+            &mut imags[..size],
+            log_half,
+            log_size,
+            planner,
+            stage_twiddle_idx,
+        )
     }
+}
+
+/// Run DIT stages from `start` to `end` (exclusive), fusing pairs of general
+/// stages into a single pass where possible (radix-2² optimization).
+/// Returns updated `stage_twiddle_idx`.
+fn run_dit_stages_f32<S: Simd>(
+    simd: S,
+    reals: &mut [f32],
+    imags: &mut [f32],
+    start: usize,
+    end: usize,
+    planner: &PlannerDit32,
+    mut stage_twiddle_idx: usize,
+) -> usize {
+    let mut stage = start;
+    while stage < end {
+        let dist = 1 << stage;
+        let chunk_size = dist * 2;
+
+        // Fuse two stages when both use general twiddles and there's a next stage
+        if chunk_size > 64 && stage + 1 < end {
+            let (tw_s_re, tw_s_im) = &planner.stage_twiddles[stage_twiddle_idx];
+            let (tw_s1_re, tw_s1_im) = &planner.stage_twiddles[stage_twiddle_idx + 1];
+            fft_dit_fused_2stage_f32_narrow(
+                simd,
+                reals,
+                imags,
+                tw_s_re,
+                tw_s_im,
+                &tw_s1_re[..dist],
+                &tw_s1_im[..dist],
+                dist,
+            );
+            stage_twiddle_idx += 2;
+            stage += 2;
+        } else {
+            stage_twiddle_idx =
+                execute_dit_stage_f32(simd, reals, imags, stage, planner, stage_twiddle_idx);
+            stage += 1;
+        }
+    }
+    stage_twiddle_idx
 }
 
 /// Recursive cache-blocked DIT FFT for f32 using post-order traversal.
@@ -98,17 +177,15 @@ fn recursive_dit_fft_f32<S: Simd>(
     let log_size = size.ilog2() as usize;
 
     if size <= L1_BLOCK_SIZE {
-        for stage in 0..log_size {
-            stage_twiddle_idx = execute_dit_stage_f32(
-                simd,
-                &mut reals[..size],
-                &mut imags[..size],
-                stage,
-                planner,
-                stage_twiddle_idx,
-            );
-        }
-        stage_twiddle_idx
+        run_dit_stages_f32(
+            simd,
+            &mut reals[..size],
+            &mut imags[..size],
+            0,
+            log_size,
+            planner,
+            stage_twiddle_idx,
+        )
     } else {
         let half = size / 2;
         let log_half = half.ilog2() as usize;
@@ -127,18 +204,15 @@ fn recursive_dit_fft_f32<S: Simd>(
         stage_twiddle_idx = log_half.saturating_sub(6);
 
         // Process remaining stages that span both halves
-        for stage in log_half..log_size {
-            stage_twiddle_idx = execute_dit_stage_f32(
-                simd,
-                &mut reals[..size],
-                &mut imags[..size],
-                stage,
-                planner,
-                stage_twiddle_idx,
-            );
-        }
-
-        stage_twiddle_idx
+        run_dit_stages_f32(
+            simd,
+            &mut reals[..size],
+            &mut imags[..size],
+            log_half,
+            log_size,
+            planner,
+            stage_twiddle_idx,
+        )
     }
 }
 

--- a/src/algorithms/dit.rs
+++ b/src/algorithms/dit.rs
@@ -71,6 +71,9 @@ fn run_dit_stages_f64<S: Simd>(
 ///
 /// Recursively divides by 2 until reaching L1 cache size, processes stages within
 /// each block, then processes cross-block stages on return.
+///
+/// When the size is large enough to split into quarters, does so to produce
+/// two cross-block stages that can be fused by the radix-2² kernel.
 fn recursive_dit_fft_f64<S: Simd>(
     simd: S,
     reals: &mut [f64],
@@ -92,24 +95,67 @@ fn recursive_dit_fft_f64<S: Simd>(
             planner,
             stage_twiddle_idx,
         )
+    } else if size >= L1_BLOCK_SIZE * 4 {
+        // Split into quarters: 4 sub-problems of size/4, then 2 cross-block stages.
+        // This gives the radix-2² fused kernel a pair of stages to work with.
+        let quarter = size / 4;
+        let log_quarter = quarter.ilog2() as usize;
+        let parallel = size > opts.smallest_parallel_chunk_size;
+
+        let (re_lo, re_hi) = reals.split_at_mut(size / 2);
+        let (im_lo, im_hi) = imags.split_at_mut(size / 2);
+        let (re_q0, re_q1) = re_lo.split_at_mut(quarter);
+        let (im_q0, im_q1) = im_lo.split_at_mut(quarter);
+        let (re_q2, re_q3) = re_hi.split_at_mut(quarter);
+        let (im_q2, im_q3) = im_hi.split_at_mut(quarter);
+
+        run_maybe_in_parallel(
+            parallel,
+            || {
+                run_maybe_in_parallel(
+                    parallel,
+                    || recursive_dit_fft_f64(simd, re_q0, im_q0, quarter, planner, opts, 0),
+                    || recursive_dit_fft_f64(simd, re_q1, im_q1, quarter, planner, opts, 0),
+                )
+            },
+            || {
+                run_maybe_in_parallel(
+                    parallel,
+                    || recursive_dit_fft_f64(simd, re_q2, im_q2, quarter, planner, opts, 0),
+                    || recursive_dit_fft_f64(simd, re_q3, im_q3, quarter, planner, opts, 0),
+                )
+            },
+        );
+
+        // All quarters completed stages 0..log_quarter-1.
+        // Now run 2 cross-block stages: log_quarter and log_quarter+1.
+        stage_twiddle_idx = log_quarter.saturating_sub(6);
+
+        run_dit_stages_f64(
+            simd,
+            &mut reals[..size],
+            &mut imags[..size],
+            log_quarter,
+            log_size,
+            planner,
+            stage_twiddle_idx,
+        )
     } else {
+        // size is between L1_BLOCK_SIZE+1 and L1_BLOCK_SIZE*4-1
+        // Split into halves: 1 cross-block stage (cannot fuse, but these are small sizes)
         let half = size / 2;
         let log_half = half.ilog2() as usize;
 
         let (re_first_half, re_second_half) = reals.split_at_mut(half);
         let (im_first_half, im_second_half) = imags.split_at_mut(half);
-        // Recursively process both halves
         run_maybe_in_parallel(
             size > opts.smallest_parallel_chunk_size,
             || recursive_dit_fft_f64(simd, re_first_half, im_first_half, half, planner, opts, 0),
             || recursive_dit_fft_f64(simd, re_second_half, im_second_half, half, planner, opts, 0),
         );
 
-        // Both halves completed stages 0..log_half-1
-        // Stages 0-5 use hardcoded twiddles, 6+ use planner
         stage_twiddle_idx = log_half.saturating_sub(6);
 
-        // Process remaining stages that span both halves
         run_dit_stages_f64(
             simd,
             &mut reals[..size],
@@ -165,6 +211,9 @@ fn run_dit_stages_f32<S: Simd>(
 }
 
 /// Recursive cache-blocked DIT FFT for f32 using post-order traversal.
+///
+/// When the size is large enough to split into quarters, does so to produce
+/// two cross-block stages that can be fused by the radix-2² kernel.
 fn recursive_dit_fft_f32<S: Simd>(
     simd: S,
     reals: &mut [f32],
@@ -186,24 +235,65 @@ fn recursive_dit_fft_f32<S: Simd>(
             planner,
             stage_twiddle_idx,
         )
+    } else if size >= L1_BLOCK_SIZE * 4 {
+        // Split into quarters: 4 sub-problems of size/4, then 2 cross-block stages.
+        let quarter = size / 4;
+        let log_quarter = quarter.ilog2() as usize;
+        let parallel = size > opts.smallest_parallel_chunk_size;
+
+        let (re_lo, re_hi) = reals.split_at_mut(size / 2);
+        let (im_lo, im_hi) = imags.split_at_mut(size / 2);
+        let (re_q0, re_q1) = re_lo.split_at_mut(quarter);
+        let (im_q0, im_q1) = im_lo.split_at_mut(quarter);
+        let (re_q2, re_q3) = re_hi.split_at_mut(quarter);
+        let (im_q2, im_q3) = im_hi.split_at_mut(quarter);
+
+        run_maybe_in_parallel(
+            parallel,
+            || {
+                run_maybe_in_parallel(
+                    parallel,
+                    || recursive_dit_fft_f32(simd, re_q0, im_q0, quarter, planner, opts, 0),
+                    || recursive_dit_fft_f32(simd, re_q1, im_q1, quarter, planner, opts, 0),
+                )
+            },
+            || {
+                run_maybe_in_parallel(
+                    parallel,
+                    || recursive_dit_fft_f32(simd, re_q2, im_q2, quarter, planner, opts, 0),
+                    || recursive_dit_fft_f32(simd, re_q3, im_q3, quarter, planner, opts, 0),
+                )
+            },
+        );
+
+        // All quarters completed stages 0..log_quarter-1.
+        // Now run 2 cross-block stages: log_quarter and log_quarter+1.
+        stage_twiddle_idx = log_quarter.saturating_sub(6);
+
+        run_dit_stages_f32(
+            simd,
+            &mut reals[..size],
+            &mut imags[..size],
+            log_quarter,
+            log_size,
+            planner,
+            stage_twiddle_idx,
+        )
     } else {
+        // size is between L1_BLOCK_SIZE+1 and L1_BLOCK_SIZE*4-1
         let half = size / 2;
         let log_half = half.ilog2() as usize;
 
         let (re_first_half, re_second_half) = reals.split_at_mut(half);
         let (im_first_half, im_second_half) = imags.split_at_mut(half);
-        // Recursively process both halves
         run_maybe_in_parallel(
             size > opts.smallest_parallel_chunk_size,
             || recursive_dit_fft_f32(simd, re_first_half, im_first_half, half, planner, opts, 0),
             || recursive_dit_fft_f32(simd, re_second_half, im_second_half, half, planner, opts, 0),
         );
 
-        // Both halves completed stages 0..log_half-1
-        // Stages 0-5 use hardcoded twiddles, 6+ use planner
         stage_twiddle_idx = log_half.saturating_sub(6);
 
-        // Process remaining stages that span both halves
         run_dit_stages_f32(
             simd,
             &mut reals[..size],

--- a/src/algorithms/dit.rs
+++ b/src/algorithms/dit.rs
@@ -230,8 +230,9 @@ fn execute_dit_stages_f64<S: Simd>(
         // When nearing the end, use the parallelized kernel because recursion doesn't parallelize enough
         #[cfg(feature = "parallel")]
         {
-            if stages_remaining >= 4 {
-                // TODO: make this dynamic based on std::thread::available_parallelism()
+            // TODO: make this dynamic based on std::thread::available_parallelism(), maybe?
+            // The jump from 16 threads to all threads is probably not very large so this is entering diminishing returns
+            if stages_remaining > 4 {
                 // Fuse two stages into a single pass over memory
                 let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
                 let (twiddles_re2, twiddles_im2) = &planner.stage_twiddles[stage_twiddle_idx + 1];

--- a/src/algorithms/dit.rs
+++ b/src/algorithms/dit.rs
@@ -327,6 +327,52 @@ fn execute_dit_stages_f32<S: Simd>(
     } else if chunk_size == 64 {
         fft_dit_chunk_64_f32(simd, reals, imags);
         (stage_twiddle_idx, 1)
+    } else if cfg!(feature = "parallel") {
+        // When nearing the end, use the parallelized kernel because recursion doesn't parallelize enough
+        #[cfg(feature = "parallel")]
+        {
+            // TODO: make this dynamic based on std::thread::available_parallelism(), maybe?
+            // The jump from 16 threads to all threads is probably not very large so this is entering diminishing returns
+            if stages_remaining > 4 {
+                // Fuse two stages into a single pass over memory
+                let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
+                let (twiddles_re2, twiddles_im2) = &planner.stage_twiddles[stage_twiddle_idx + 1];
+                fft_dit_fused_2stage_f32_narrow(
+                    simd,
+                    reals,
+                    imags,
+                    twiddles_re,
+                    twiddles_im,
+                    twiddles_re2,
+                    twiddles_im2,
+                    dist,
+                );
+                (stage_twiddle_idx + 2, 2)
+            } else if stages_remaining >= 2 {
+                let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
+                let (twiddles_re2, twiddles_im2) = &planner.stage_twiddles[stage_twiddle_idx + 1];
+                fft_dit_fused_2stage_f32_narrow_parallel(
+                    simd,
+                    reals,
+                    imags,
+                    twiddles_re,
+                    twiddles_im,
+                    twiddles_re2,
+                    twiddles_im2,
+                    dist,
+                );
+                (stage_twiddle_idx + 2, 2)
+            } else {
+                // Last stage (odd number of stages remaining), use single-stage kernel
+                let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
+                fft_dit_chunk_n_f32(simd, reals, imags, twiddles_re, twiddles_im, dist);
+                (stage_twiddle_idx + 1, 1)
+            }
+            #[cfg(not(feature = "parallel"))]
+            {
+                unreachable!()
+            }
+        }
     } else if stages_remaining >= 2 {
         // Fuse two stages into a single pass over memory
         let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];

--- a/src/algorithms/dit.rs
+++ b/src/algorithms/dit.rs
@@ -226,6 +226,13 @@ fn execute_dit_stages_f64<S: Simd>(
     } else if chunk_size == 64 {
         fft_dit_chunk_64_f64(simd, reals, imags);
         (stage_twiddle_idx, 1)
+    } else if stages_remaining % 2 == 1 {
+        // odd number of stages remaining, use single-stage kernel ASAP
+        // because the fused kernels are more efficient on memory bandwidth than this one
+        // TODO: validate experimentally whether a separate parallel radix-2 kernel at the end is worth it
+        let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
+        fft_dit_chunk_n_f64(simd, reals, imags, twiddles_re, twiddles_im, dist);
+        (stage_twiddle_idx + 1, 1)
     } else {
         #[cfg(feature = "parallel")]
         {
@@ -325,10 +332,10 @@ fn execute_dit_stages_f32<S: Simd>(
     } else if chunk_size == 64 {
         fft_dit_chunk_64_f32(simd, reals, imags);
         (stage_twiddle_idx, 1)
-    } else if cfg!(feature = "parallel") {
-        // When nearing the end, use the parallelized kernel because recursion doesn't parallelize enough
+    } else {
         #[cfg(feature = "parallel")]
         {
+            // When nearing the end, use the parallelized kernel because recursion doesn't parallelize enough
             // TODO: make this dynamic based on std::thread::available_parallelism(), maybe?
             // The jump from 16 threads to all threads is probably not very large so this is entering diminishing returns
             if stages_remaining > 4 {
@@ -366,31 +373,29 @@ fn execute_dit_stages_f32<S: Simd>(
                 fft_dit_chunk_n_f32(simd, reals, imags, twiddles_re, twiddles_im, dist);
                 (stage_twiddle_idx + 1, 1)
             }
-            #[cfg(not(feature = "parallel"))]
-            {
-                unreachable!()
-            }
         }
-    } else if stages_remaining >= 2 {
-        // Fuse two stages into a single pass over memory
-        let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
-        let (twiddles_re2, twiddles_im2) = &planner.stage_twiddles[stage_twiddle_idx + 1];
-        fft_dit_fused_2stage_f32_narrow(
-            simd,
-            reals,
-            imags,
-            twiddles_re,
-            twiddles_im,
-            twiddles_re2,
-            twiddles_im2,
-            dist,
-        );
-        (stage_twiddle_idx + 2, 2)
-    } else {
-        // Last stage (odd number of stages remaining), use single-stage kernel
-        let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
-        fft_dit_chunk_n_f32(simd, reals, imags, twiddles_re, twiddles_im, dist);
-        (stage_twiddle_idx + 1, 1)
+        #[cfg(not(feature = "parallel"))]
+        if stages_remaining >= 2 {
+            // Fuse two stages into a single pass over memory
+            let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
+            let (twiddles_re2, twiddles_im2) = &planner.stage_twiddles[stage_twiddle_idx + 1];
+            fft_dit_fused_2stage_f32_narrow(
+                simd,
+                reals,
+                imags,
+                twiddles_re,
+                twiddles_im,
+                twiddles_re2,
+                twiddles_im2,
+                dist,
+            );
+            (stage_twiddle_idx + 2, 2)
+        } else {
+            // Last stage (odd number of stages remaining), use single-stage kernel
+            let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
+            fft_dit_chunk_n_f32(simd, reals, imags, twiddles_re, twiddles_im, dist);
+            (stage_twiddle_idx + 1, 1)
+        }
     }
 }
 

--- a/src/algorithms/dit.rs
+++ b/src/algorithms/dit.rs
@@ -124,44 +124,70 @@ fn recursive_dit_fft_f32<S: Simd>(
     let log_size = size.ilog2() as usize;
 
     if size <= L1_BLOCK_SIZE {
-        for stage in 0..log_size {
-            stage_twiddle_idx = execute_dit_stage_f32(
+        let mut stage = 0;
+        while stage < log_size {
+            let (new_idx, consumed) = execute_dit_stages_f32(
                 simd,
                 &mut reals[..size],
                 &mut imags[..size],
                 stage,
+                log_size - stage,
                 planner,
                 stage_twiddle_idx,
             );
+            stage_twiddle_idx = new_idx;
+            stage += consumed;
         }
         stage_twiddle_idx
     } else {
-        let half = size / 2;
-        let log_half = half.ilog2() as usize;
+        let quarter = size / 4;
+        let log_quarter = quarter.ilog2() as usize;
 
-        let (re_first_half, re_second_half) = reals.split_at_mut(half);
-        let (im_first_half, im_second_half) = imags.split_at_mut(half);
-        // Recursively process both halves
+        let (re_lo, re_hi) = reals.split_at_mut(size / 2);
+        let (im_lo, im_hi) = imags.split_at_mut(size / 2);
+        let (re_q0, re_q1) = re_lo.split_at_mut(quarter);
+        let (im_q0, im_q1) = im_lo.split_at_mut(quarter);
+        let (re_q2, re_q3) = re_hi.split_at_mut(quarter);
+        let (im_q2, im_q3) = im_hi.split_at_mut(quarter);
+
+        // Recursively process all 4 quarters (parallel across pairs)
         run_maybe_in_parallel(
             size > opts.smallest_parallel_chunk_size,
-            || recursive_dit_fft_f32(simd, re_first_half, im_first_half, half, planner, opts, 0),
-            || recursive_dit_fft_f32(simd, re_second_half, im_second_half, half, planner, opts, 0),
+            || {
+                run_maybe_in_parallel(
+                    size / 2 > opts.smallest_parallel_chunk_size,
+                    || recursive_dit_fft_f32(simd, re_q0, im_q0, quarter, planner, opts, 0),
+                    || recursive_dit_fft_f32(simd, re_q1, im_q1, quarter, planner, opts, 0),
+                )
+            },
+            || {
+                run_maybe_in_parallel(
+                    size / 2 > opts.smallest_parallel_chunk_size,
+                    || recursive_dit_fft_f32(simd, re_q2, im_q2, quarter, planner, opts, 0),
+                    || recursive_dit_fft_f32(simd, re_q3, im_q3, quarter, planner, opts, 0),
+                )
+            },
         );
 
-        // Both halves completed stages 0..log_half-1
+        // All 4 quarters completed stages 0..log_quarter-1.
+        // Now process the 2 remaining cross-block stages (log_quarter and log_quarter+1)
+        // using the fused kernel.
         // Stages 0-5 use hardcoded twiddles, 6+ use planner
-        stage_twiddle_idx = log_half.saturating_sub(6);
+        stage_twiddle_idx = log_quarter.saturating_sub(6);
 
-        // Process remaining stages that span both halves
-        for stage in log_half..log_size {
-            stage_twiddle_idx = execute_dit_stage_f32(
+        let mut stage = log_quarter;
+        while stage < log_size {
+            let (new_idx, consumed) = execute_dit_stages_f32(
                 simd,
                 &mut reals[..size],
                 &mut imags[..size],
                 stage,
+                log_size - stage,
                 planner,
                 stage_twiddle_idx,
             );
+            stage_twiddle_idx = new_idx;
+            stage += consumed;
         }
 
         stage_twiddle_idx
@@ -223,42 +249,58 @@ fn execute_dit_stages_f64<S: Simd>(
     }
 }
 
-/// Execute a single DIT stage, dispatching to appropriate kernel based on chunk size.
-/// Returns updated stage_twiddle_idx.
-fn execute_dit_stage_f32<S: Simd>(
+/// Execute one or two DIT stages, dispatching to appropriate kernel based on chunk size.
+/// Returns (updated stage_twiddle_idx, number of stages consumed).
+fn execute_dit_stages_f32<S: Simd>(
     simd: S,
     reals: &mut [f32],
     imags: &mut [f32],
     stage: usize,
+    stages_remaining: usize,
     planner: &PlannerDit32,
     stage_twiddle_idx: usize,
-) -> usize {
+) -> (usize, usize) {
     let dist = 1 << stage; // 2.pow(stage)
     let chunk_size = dist * 2;
 
     if chunk_size == 2 {
         simd.vectorize(|| fft_dit_chunk_2(simd, reals, imags));
-        stage_twiddle_idx
+        (stage_twiddle_idx, 1)
     } else if chunk_size == 4 {
         fft_dit_chunk_4_f32(simd, reals, imags);
-        stage_twiddle_idx
+        (stage_twiddle_idx, 1)
     } else if chunk_size == 8 {
         fft_dit_chunk_8_f32(simd, reals, imags);
-        stage_twiddle_idx
+        (stage_twiddle_idx, 1)
     } else if chunk_size == 16 {
         fft_dit_chunk_16_f32(simd, reals, imags);
-        stage_twiddle_idx
+        (stage_twiddle_idx, 1)
     } else if chunk_size == 32 {
         fft_dit_chunk_32_f32(simd, reals, imags);
-        stage_twiddle_idx
+        (stage_twiddle_idx, 1)
     } else if chunk_size == 64 {
         fft_dit_chunk_64_f32(simd, reals, imags);
-        stage_twiddle_idx
+        (stage_twiddle_idx, 1)
+    } else if stages_remaining >= 2 {
+        // Fuse two stages into a single pass over memory
+        let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
+        let (twiddles_re2, twiddles_im2) = &planner.stage_twiddles[stage_twiddle_idx + 1];
+        fft_dit_fused_2stage_f32_narrow(
+            simd,
+            reals,
+            imags,
+            twiddles_re,
+            twiddles_im,
+            twiddles_re2,
+            twiddles_im2,
+            dist,
+        );
+        (stage_twiddle_idx + 2, 2)
     } else {
-        // For larger chunks, use general kernel with twiddles from planner
+        // Last stage (odd number of stages remaining), use single-stage kernel
         let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
         fft_dit_chunk_n_f32(simd, reals, imags, twiddles_re, twiddles_im, dist);
-        stage_twiddle_idx + 1
+        (stage_twiddle_idx + 1, 1)
     }
 }
 

--- a/src/algorithms/dit.rs
+++ b/src/algorithms/dit.rs
@@ -37,7 +37,6 @@ fn recursive_dit_fft_f64<S: Simd>(
     planner: &PlannerDit64,
     opts: &Options,
     mut stage_twiddle_idx: usize,
-    is_top_level: bool,
 ) -> usize {
     let log_size = size.ilog2() as usize;
 
@@ -74,15 +73,15 @@ fn recursive_dit_fft_f64<S: Simd>(
             || {
                 run_maybe_in_parallel(
                     size / 2 > opts.smallest_parallel_chunk_size,
-                    || recursive_dit_fft_f64(simd, re_q0, im_q0, quarter, planner, opts, 0, false),
-                    || recursive_dit_fft_f64(simd, re_q1, im_q1, quarter, planner, opts, 0, false),
+                    || recursive_dit_fft_f64(simd, re_q0, im_q0, quarter, planner, opts, 0),
+                    || recursive_dit_fft_f64(simd, re_q1, im_q1, quarter, planner, opts, 0),
                 )
             },
             || {
                 run_maybe_in_parallel(
                     size / 2 > opts.smallest_parallel_chunk_size,
-                    || recursive_dit_fft_f64(simd, re_q2, im_q2, quarter, planner, opts, 0, false),
-                    || recursive_dit_fft_f64(simd, re_q3, im_q3, quarter, planner, opts, 0, false),
+                    || recursive_dit_fft_f64(simd, re_q2, im_q2, quarter, planner, opts, 0),
+                    || recursive_dit_fft_f64(simd, re_q3, im_q3, quarter, planner, opts, 0),
                 )
             },
         );
@@ -94,39 +93,13 @@ fn recursive_dit_fft_f64<S: Simd>(
         stage_twiddle_idx = log_quarter.saturating_sub(6);
 
         let mut stage = log_quarter;
-        let _ = is_top_level; // used only with "parallel" feature
         while stage < log_size {
-            let stages_remaining = log_size - stage;
-
-            // At the top level, the last fused 2-stage pass spans the entire array
-            // and cannot be parallelized through recursion, so use the parallel kernel.
-            #[cfg(feature = "parallel")]
-            if is_top_level && stages_remaining >= 2 && (1 << stage) * 2 > 64 {
-                let dist = 1 << stage;
-                let (twiddles_re, twiddles_im) = &planner.stage_twiddles[stage_twiddle_idx];
-                let (twiddles_re2, twiddles_im2) =
-                    &planner.stage_twiddles[stage_twiddle_idx + 1];
-                fft_dit_fused_2stage_f64_narrow_parallel(
-                    simd,
-                    &mut reals[..size],
-                    &mut imags[..size],
-                    twiddles_re,
-                    twiddles_im,
-                    twiddles_re2,
-                    twiddles_im2,
-                    dist,
-                );
-                stage_twiddle_idx += 2;
-                stage += 2;
-                continue;
-            }
-
             let (new_idx, consumed) = execute_dit_stages_f64(
                 simd,
                 &mut reals[..size],
                 &mut imags[..size],
                 stage,
-                stages_remaining,
+                log_size - stage,
                 planner,
                 stage_twiddle_idx,
             );
@@ -401,7 +374,7 @@ fn fft_64_dit_with_planner_and_opts_impl<S: Simd>(
 
     simd.vectorize(
         #[inline(always)]
-        || recursive_dit_fft_f64(simd, reals, imags, n, planner, opts, 0, true),
+        || recursive_dit_fft_f64(simd, reals, imags, n, planner, opts, 0),
     );
 
     // Scaling for inverse transform

--- a/src/kernels/dit.rs
+++ b/src/kernels/dit.rs
@@ -1043,6 +1043,79 @@ fn fft_dit_chunk_n_simd_f64<S: Simd>(
     }
 }
 
+/// General DIT butterfly for f64 (narrow SIMD: f64x4)
+///
+/// Uses 4-lane SIMD instead of 8-lane to reduce register pressure.
+#[inline(never)] // otherwise every kernel gets inlined into the parent
+pub fn fft_dit_chunk_n_f64_narrow<S: Simd>(
+    simd: S,
+    reals: &mut [f64],
+    imags: &mut [f64],
+    twiddles_re: &[f64],
+    twiddles_im: &[f64],
+    dist: usize,
+) {
+    simd.vectorize(
+        #[inline(always)]
+        || fft_dit_chunk_n_simd_f64_narrow(simd, reals, imags, twiddles_re, twiddles_im, dist),
+    )
+}
+
+/// General DIT butterfly for f64 (narrow SIMD: f64x4)
+#[inline(always)] // required by fearless_simd
+fn fft_dit_chunk_n_simd_f64_narrow<S: Simd>(
+    simd: S,
+    reals: &mut [f64],
+    imags: &mut [f64],
+    twiddles_re: &[f64],
+    twiddles_im: &[f64],
+    dist: usize,
+) {
+    const LANES: usize = 4;
+    let chunk_size = dist * 2;
+    assert!(chunk_size >= LANES * 2);
+
+    // see fft_dit_chunk_n_simd_f64 for an explanation of this structure
+    for (reals_chunk, imags_chunk) in reals
+        .chunks_exact_mut(chunk_size)
+        .zip(imags.chunks_exact_mut(chunk_size))
+    {
+        let (reals_s0, reals_s1) = reals_chunk.split_at_mut(dist);
+        let (imags_s0, imags_s1) = imags_chunk.split_at_mut(dist);
+
+        (reals_s0.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(reals_s1.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(imags_s0.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(imags_s1.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(twiddles_re.as_chunks::<LANES>().0.iter())
+            .zip(twiddles_im.as_chunks::<LANES>().0.iter())
+            .for_each(|(((((re_s0, re_s1), im_s0), im_s1), tw_re), tw_im)| {
+                let two = f64x4::splat(simd, 2.0);
+                let in0_re = f64x4::simd_from(simd, *re_s0);
+                let in1_re = f64x4::simd_from(simd, *re_s1);
+                let in0_im = f64x4::simd_from(simd, *im_s0);
+                let in1_im = f64x4::simd_from(simd, *im_s1);
+
+                let tw_re = f64x4::simd_from(simd, *tw_re);
+                let tw_im = f64x4::simd_from(simd, *tw_im);
+
+                // out0.re = (in0.re + tw_re * in1.re) - tw_im * in1.im
+                let out0_re = tw_im.mul_add(-in1_im, tw_re.mul_add(in1_re, in0_re));
+                // out0.im = (in0.im + tw_re * in1.im) + tw_im * in1.re
+                let out0_im = tw_im.mul_add(in1_re, tw_re.mul_add(in1_im, in0_im));
+
+                // Use FMA for out1 = 2*in0 - out0
+                let out1_re = two.mul_sub(in0_re, out0_re);
+                let out1_im = two.mul_sub(in0_im, out0_im);
+
+                out0_re.store_slice(re_s0);
+                out0_im.store_slice(im_s0);
+                out1_re.store_slice(re_s1);
+                out1_im.store_slice(im_s1);
+            });
+    }
+}
+
 /// General DIT butterfly for f32
 #[inline(never)] // otherwise every kernel gets inlined into the parent
 pub fn fft_dit_chunk_n_f32<S: Simd>(
@@ -1096,6 +1169,79 @@ fn fft_dit_chunk_n_simd_f32<S: Simd>(
 
                 let tw_re = f32x16::simd_from(simd, *tw_re);
                 let tw_im = f32x16::simd_from(simd, *tw_im);
+
+                // out0.re = (in0.re + tw_re * in1.re) - tw_im * in1.im
+                let out0_re = tw_im.mul_add(-in1_im, tw_re.mul_add(in1_re, in0_re));
+                // out0.im = (in0.im + tw_re * in1.im) + tw_im * in1.re
+                let out0_im = tw_im.mul_add(in1_re, tw_re.mul_add(in1_im, in0_im));
+
+                // Use FMA for out1 = 2*in0 - out0
+                let out1_re = two.mul_sub(in0_re, out0_re);
+                let out1_im = two.mul_sub(in0_im, out0_im);
+
+                out0_re.store_slice(re_s0);
+                out0_im.store_slice(im_s0);
+                out1_re.store_slice(re_s1);
+                out1_im.store_slice(im_s1);
+            });
+    }
+}
+
+/// General DIT butterfly for f32 (narrow SIMD: f32x8)
+///
+/// Uses 8-lane SIMD instead of 16-lane to reduce register pressure.
+#[inline(never)] // otherwise every kernel gets inlined into the parent
+pub fn fft_dit_chunk_n_f32_narrow<S: Simd>(
+    simd: S,
+    reals: &mut [f32],
+    imags: &mut [f32],
+    twiddles_re: &[f32],
+    twiddles_im: &[f32],
+    dist: usize,
+) {
+    simd.vectorize(
+        #[inline(always)]
+        || fft_dit_chunk_n_simd_f32_narrow(simd, reals, imags, twiddles_re, twiddles_im, dist),
+    )
+}
+
+/// General DIT butterfly for f32 (narrow SIMD: f32x8)
+#[inline(always)] // required by fearless_simd
+fn fft_dit_chunk_n_simd_f32_narrow<S: Simd>(
+    simd: S,
+    reals: &mut [f32],
+    imags: &mut [f32],
+    twiddles_re: &[f32],
+    twiddles_im: &[f32],
+    dist: usize,
+) {
+    const LANES: usize = 8;
+    let chunk_size = dist * 2;
+    assert!(chunk_size >= LANES * 2);
+
+    // see fft_dit_chunk_n_simd_f64 for an explanation of this structure
+    for (reals_chunk, imags_chunk) in reals
+        .chunks_exact_mut(chunk_size)
+        .zip(imags.chunks_exact_mut(chunk_size))
+    {
+        let (reals_s0, reals_s1) = reals_chunk.split_at_mut(dist);
+        let (imags_s0, imags_s1) = imags_chunk.split_at_mut(dist);
+
+        (reals_s0.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(reals_s1.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(imags_s0.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(imags_s1.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(twiddles_re.as_chunks::<LANES>().0.iter())
+            .zip(twiddles_im.as_chunks::<LANES>().0.iter())
+            .for_each(|(((((re_s0, re_s1), im_s0), im_s1), tw_re), tw_im)| {
+                let two = f32x8::splat(simd, 2.0);
+                let in0_re = f32x8::simd_from(simd, *re_s0);
+                let in1_re = f32x8::simd_from(simd, *re_s1);
+                let in0_im = f32x8::simd_from(simd, *im_s0);
+                let in1_im = f32x8::simd_from(simd, *im_s1);
+
+                let tw_re = f32x8::simd_from(simd, *tw_re);
+                let tw_im = f32x8::simd_from(simd, *tw_im);
 
                 // out0.re = (in0.re + tw_re * in1.re) - tw_im * in1.im
                 let out0_re = tw_im.mul_add(-in1_im, tw_re.mul_add(in1_re, in0_re));

--- a/src/kernels/dit.rs
+++ b/src/kernels/dit.rs
@@ -1700,3 +1700,153 @@ fn fft_dit_fused_2stage_simd_f32_narrow<S: Simd>(
             );
     }
 }
+
+#[inline(never)]
+pub fn fft_dit_fused_2stage_f32_narrow_parallel<S: Simd>(
+    simd: S,
+    reals: &mut [f32],
+    imags: &mut [f32],
+    twiddles_s_re: &[f32],
+    twiddles_s_im: &[f32],
+    twiddles_s1_re: &[f32],
+    twiddles_s1_im: &[f32],
+    dist_s: usize,
+) {
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            fft_dit_fused_2stage_simd_f32_narrow_parallel(
+                simd,
+                reals,
+                imags,
+                twiddles_s_re,
+                twiddles_s_im,
+                twiddles_s1_re,
+                twiddles_s1_im,
+                dist_s,
+            )
+        },
+    )
+}
+
+/// Fused two-stage DIT butterfly for f32 (radix-2², narrow SIMD: f32x8) that runs multi-threaded
+#[cfg(feature = "parallel")]
+#[inline(always)]
+fn fft_dit_fused_2stage_simd_f32_narrow_parallel<S: Simd>(
+    simd: S,
+    reals: &mut [f32],
+    imags: &mut [f32],
+    twiddles_s_re: &[f32],
+    twiddles_s_im: &[f32],
+    twiddles_s1_re: &[f32],
+    twiddles_s1_im: &[f32],
+    dist_s: usize,
+) {
+    use rayon::prelude::*;
+    const LANES: usize = 8;
+    let block_size = dist_s * 4; // two stages: 4 sub-blocks of dist_s
+    assert!(dist_s >= LANES);
+
+    // Outer loop over blocks of 4*dist_s elements.
+    // Using `for` (not `for_each`) for the same inlining reasons
+    // as in fft_dit_chunk_n_simd_f32.
+    for (reals_block, imags_block) in reals
+        .chunks_exact_mut(block_size)
+        .zip(imags.chunks_exact_mut(block_size))
+    {
+        // Split block into 4 sub-blocks of dist_s elements:
+        // A = [0..D), B = [D..2D), C = [2D..3D), D_blk = [3D..4D)
+        let (re_ab, re_cd) = reals_block.split_at_mut(dist_s * 2);
+        let (im_ab, im_cd) = imags_block.split_at_mut(dist_s * 2);
+        let (re_a, re_b) = re_ab.split_at_mut(dist_s);
+        let (im_a, im_b) = im_ab.split_at_mut(dist_s);
+        let (re_c, re_d) = re_cd.split_at_mut(dist_s);
+        let (im_c, im_d) = im_cd.split_at_mut(dist_s);
+
+        (re_a.as_chunks_mut::<LANES>().0.par_iter_mut())
+            .zip(re_b.as_chunks_mut::<LANES>().0.par_iter_mut())
+            .zip(re_c.as_chunks_mut::<LANES>().0.par_iter_mut())
+            .zip(re_d.as_chunks_mut::<LANES>().0.par_iter_mut())
+            .zip(im_a.as_chunks_mut::<LANES>().0.par_iter_mut())
+            .zip(im_b.as_chunks_mut::<LANES>().0.par_iter_mut())
+            .zip(im_c.as_chunks_mut::<LANES>().0.par_iter_mut())
+            .zip(im_d.as_chunks_mut::<LANES>().0.par_iter_mut())
+            .zip(twiddles_s_re.as_chunks::<LANES>().0.par_iter())
+            .zip(twiddles_s_im.as_chunks::<LANES>().0.par_iter())
+            .zip(twiddles_s1_re.as_chunks::<LANES>().0.par_iter())
+            .zip(twiddles_s1_im.as_chunks::<LANES>().0.par_iter())
+            .for_each(
+                |(
+                    ((((((((((ra, rb), rc), rd), ia), ib), ic), id), tw_s_re), tw_s_im), tw1_re),
+                    tw1_im,
+                )| {
+                    simd.vectorize(
+                        #[inline(always)]
+                        || {
+                            let two = f32x8::splat(simd, 2.0);
+
+                            // Load 4 data sub-blocks
+                            let a_re = f32x8::simd_from(simd, *ra);
+                            let a_im = f32x8::simd_from(simd, *ia);
+                            let b_re = f32x8::simd_from(simd, *rb);
+                            let b_im = f32x8::simd_from(simd, *ib);
+                            let c_re = f32x8::simd_from(simd, *rc);
+                            let c_im = f32x8::simd_from(simd, *ic);
+                            let d_re = f32x8::simd_from(simd, *rd);
+                            let d_im = f32x8::simd_from(simd, *id);
+
+                            // Load stage-s twiddles
+                            let tws_re = f32x8::simd_from(simd, *tw_s_re);
+                            let tws_im = f32x8::simd_from(simd, *tw_s_im);
+
+                            // Stage s butterfly: (A,B) pair
+                            // A' = A + tw_s * B,  B' = A - tw_s * B
+                            let ap_re = tws_im.mul_add(-b_im, tws_re.mul_add(b_re, a_re));
+                            let ap_im = tws_im.mul_add(b_re, tws_re.mul_add(b_im, a_im));
+                            let bp_re = two.mul_sub(a_re, ap_re);
+                            let bp_im = two.mul_sub(a_im, ap_im);
+
+                            // Stage s butterfly: (C,D) pair
+                            // C' = C + tw_s * D,  D' = C - tw_s * D
+                            let cp_re = tws_im.mul_add(-d_im, tws_re.mul_add(d_re, c_re));
+                            let cp_im = tws_im.mul_add(d_re, tws_re.mul_add(d_im, c_im));
+                            let dp_re = two.mul_sub(c_re, cp_re);
+                            let dp_im = two.mul_sub(c_im, cp_im);
+
+                            // Load stage-(s+1) twiddles (first half only)
+                            let tw1r = f32x8::simd_from(simd, *tw1_re);
+                            let tw1i = f32x8::simd_from(simd, *tw1_im);
+
+                            // Stage s+1 butterfly: (A', C') pair with tw_{s+1}[k]
+                            // out_A = A' + tw1 * C',  out_C = A' - tw1 * C'
+                            let out_a_re = tw1i.mul_add(-cp_im, tw1r.mul_add(cp_re, ap_re));
+                            let out_a_im = tw1i.mul_add(cp_re, tw1r.mul_add(cp_im, ap_im));
+                            let out_c_re = two.mul_sub(ap_re, out_a_re);
+                            let out_c_im = two.mul_sub(ap_im, out_a_im);
+
+                            // Derive -j * tw1: (-j)(w_re + i*w_im) = w_im - i*w_re
+                            let nj_tw1r = tw1i;
+                            let nj_tw1i = -tw1r;
+
+                            // Stage s+1 butterfly: (B', D') pair with -j * tw_{s+1}[k]
+                            // out_B = B' + (-j*tw1) * D',  out_D = B' - (-j*tw1) * D'
+                            let out_b_re = nj_tw1i.mul_add(-dp_im, nj_tw1r.mul_add(dp_re, bp_re));
+                            let out_b_im = nj_tw1i.mul_add(dp_re, nj_tw1r.mul_add(dp_im, bp_im));
+                            let out_d_re = two.mul_sub(bp_re, out_b_re);
+                            let out_d_im = two.mul_sub(bp_im, out_b_im);
+
+                            // Store results
+                            out_a_re.store_slice(ra);
+                            out_a_im.store_slice(ia);
+                            out_b_re.store_slice(rb);
+                            out_b_im.store_slice(ib);
+                            out_c_re.store_slice(rc);
+                            out_c_im.store_slice(ic);
+                            out_d_re.store_slice(rd);
+                            out_d_im.store_slice(id);
+                        },
+                    );
+                },
+            );
+    }
+}

--- a/src/kernels/dit.rs
+++ b/src/kernels/dit.rs
@@ -1297,6 +1297,40 @@ pub fn fft_dit_fused_2stage_f64_narrow<S: Simd>(
     )
 }
 
+/// Parallel fused two-stage DIT butterfly for f64 (radix-2², narrow SIMD: f64x4)
+///
+/// Same as [`fft_dit_fused_2stage_f64_narrow`] but parallelizes the inner loop
+/// using Rayon. Intended for the last stage of the FFT which spans the entire array
+/// and cannot be parallelized through recursion.
+#[cfg(feature = "parallel")]
+#[inline(never)]
+pub fn fft_dit_fused_2stage_f64_narrow_parallel<S: Simd>(
+    simd: S,
+    reals: &mut [f64],
+    imags: &mut [f64],
+    twiddles_s_re: &[f64],
+    twiddles_s_im: &[f64],
+    twiddles_s1_re: &[f64],
+    twiddles_s1_im: &[f64],
+    dist_s: usize,
+) {
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            fft_dit_fused_2stage_simd_f64_narrow_parallel(
+                simd,
+                reals,
+                imags,
+                twiddles_s_re,
+                twiddles_s_im,
+                twiddles_s1_re,
+                twiddles_s1_im,
+                dist_s,
+            )
+        },
+    )
+}
+
 /// Fused two-stage DIT butterfly for f64 (radix-2², narrow SIMD: f64x4)
 #[inline(always)]
 fn fft_dit_fused_2stage_simd_f64_narrow<S: Simd>(

--- a/src/kernels/dit.rs
+++ b/src/kernels/dit.rs
@@ -1412,6 +1412,34 @@ fn fft_dit_fused_2stage_simd_f64_narrow<S: Simd>(
     }
 }
 
+#[inline(never)]
+pub fn fft_dit_fused_2stage_f64_narrow_parallel<S: Simd>(
+    simd: S,
+    reals: &mut [f64],
+    imags: &mut [f64],
+    twiddles_s_re: &[f64],
+    twiddles_s_im: &[f64],
+    twiddles_s1_re: &[f64],
+    twiddles_s1_im: &[f64],
+    dist_s: usize,
+) {
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            fft_dit_fused_2stage_simd_f64_narrow_parallel(
+                simd,
+                reals,
+                imags,
+                twiddles_s_re,
+                twiddles_s_im,
+                twiddles_s1_re,
+                twiddles_s1_im,
+                dist_s,
+            )
+        },
+    )
+}
+
 /// Fused two-stage DIT butterfly for f64 (radix-2², narrow SIMD: f64x4) that runs multi-threaded
 #[cfg(feature = "parallel")]
 #[inline(always)]

--- a/src/kernels/dit.rs
+++ b/src/kernels/dit.rs
@@ -1412,6 +1412,7 @@ fn fft_dit_fused_2stage_simd_f64_narrow<S: Simd>(
     }
 }
 
+#[cfg(feature = "parallel")]
 #[inline(never)]
 pub fn fft_dit_fused_2stage_f64_narrow_parallel<S: Simd>(
     simd: S,
@@ -1701,6 +1702,7 @@ fn fft_dit_fused_2stage_simd_f32_narrow<S: Simd>(
     }
 }
 
+#[cfg(feature = "parallel")]
 #[inline(never)]
 pub fn fft_dit_fused_2stage_f32_narrow_parallel<S: Simd>(
     simd: S,

--- a/src/kernels/dit.rs
+++ b/src/kernels/dit.rs
@@ -1412,6 +1412,128 @@ fn fft_dit_fused_2stage_simd_f64_narrow<S: Simd>(
     }
 }
 
+/// Fused two-stage DIT butterfly for f64 (radix-2², narrow SIMD: f64x4) that runs multi-threaded
+#[cfg(feature = "parallel")]
+#[inline(always)]
+fn fft_dit_fused_2stage_simd_f64_narrow_parallel<S: Simd>(
+    simd: S,
+    reals: &mut [f64],
+    imags: &mut [f64],
+    twiddles_s_re: &[f64],
+    twiddles_s_im: &[f64],
+    twiddles_s1_re: &[f64],
+    twiddles_s1_im: &[f64],
+    dist_s: usize,
+) {
+    use rayon::prelude::*;
+    const LANES: usize = 4;
+    let block_size = dist_s * 4; // two stages: 4 sub-blocks of dist_s
+    assert!(dist_s >= LANES);
+
+    // Outer loop over blocks of 4*dist_s elements.
+    // Using `for` (not `for_each`) for the same inlining reasons
+    // as in fft_dit_chunk_n_simd_f64.
+    for (reals_block, imags_block) in reals
+        .chunks_exact_mut(block_size)
+        .zip(imags.chunks_exact_mut(block_size))
+    {
+        // Split block into 4 sub-blocks of dist_s elements:
+        // A = [0..D), B = [D..2D), C = [2D..3D), D_blk = [3D..4D)
+        let (re_ab, re_cd) = reals_block.split_at_mut(dist_s * 2);
+        let (im_ab, im_cd) = imags_block.split_at_mut(dist_s * 2);
+        let (re_a, re_b) = re_ab.split_at_mut(dist_s);
+        let (im_a, im_b) = im_ab.split_at_mut(dist_s);
+        let (re_c, re_d) = re_cd.split_at_mut(dist_s);
+        let (im_c, im_d) = im_cd.split_at_mut(dist_s);
+
+        (re_a.as_chunks_mut::<LANES>().0.par_iter_mut())
+            .zip(re_b.as_chunks_mut::<LANES>().0.par_iter_mut())
+            .zip(re_c.as_chunks_mut::<LANES>().0.par_iter_mut())
+            .zip(re_d.as_chunks_mut::<LANES>().0.par_iter_mut())
+            .zip(im_a.as_chunks_mut::<LANES>().0.par_iter_mut())
+            .zip(im_b.as_chunks_mut::<LANES>().0.par_iter_mut())
+            .zip(im_c.as_chunks_mut::<LANES>().0.par_iter_mut())
+            .zip(im_d.as_chunks_mut::<LANES>().0.par_iter_mut())
+            .zip(twiddles_s_re.as_chunks::<LANES>().0.par_iter())
+            .zip(twiddles_s_im.as_chunks::<LANES>().0.par_iter())
+            .zip(twiddles_s1_re.as_chunks::<LANES>().0.par_iter())
+            .zip(twiddles_s1_im.as_chunks::<LANES>().0.par_iter())
+            .for_each(
+                |(
+                    ((((((((((ra, rb), rc), rd), ia), ib), ic), id), tw_s_re), tw_s_im), tw1_re),
+                    tw1_im,
+                )| {
+                    simd.vectorize(
+                        #[inline(always)]
+                        || {
+                            let two = f64x4::splat(simd, 2.0);
+
+                            // Load 4 data sub-blocks
+                            let a_re = f64x4::simd_from(simd, *ra);
+                            let a_im = f64x4::simd_from(simd, *ia);
+                            let b_re = f64x4::simd_from(simd, *rb);
+                            let b_im = f64x4::simd_from(simd, *ib);
+                            let c_re = f64x4::simd_from(simd, *rc);
+                            let c_im = f64x4::simd_from(simd, *ic);
+                            let d_re = f64x4::simd_from(simd, *rd);
+                            let d_im = f64x4::simd_from(simd, *id);
+
+                            // Load stage-s twiddles
+                            let tws_re = f64x4::simd_from(simd, *tw_s_re);
+                            let tws_im = f64x4::simd_from(simd, *tw_s_im);
+
+                            // Stage s butterfly: (A,B) pair
+                            // A' = A + tw_s * B,  B' = A - tw_s * B
+                            let ap_re = tws_im.mul_add(-b_im, tws_re.mul_add(b_re, a_re));
+                            let ap_im = tws_im.mul_add(b_re, tws_re.mul_add(b_im, a_im));
+                            let bp_re = two.mul_sub(a_re, ap_re);
+                            let bp_im = two.mul_sub(a_im, ap_im);
+
+                            // Stage s butterfly: (C,D) pair
+                            // C' = C + tw_s * D,  D' = C - tw_s * D
+                            let cp_re = tws_im.mul_add(-d_im, tws_re.mul_add(d_re, c_re));
+                            let cp_im = tws_im.mul_add(d_re, tws_re.mul_add(d_im, c_im));
+                            let dp_re = two.mul_sub(c_re, cp_re);
+                            let dp_im = two.mul_sub(c_im, cp_im);
+
+                            // Load stage-(s+1) twiddles (first half only)
+                            let tw1r = f64x4::simd_from(simd, *tw1_re);
+                            let tw1i = f64x4::simd_from(simd, *tw1_im);
+
+                            // Stage s+1 butterfly: (A', C') pair with tw_{s+1}[k]
+                            // out_A = A' + tw1 * C',  out_C = A' - tw1 * C'
+                            let out_a_re = tw1i.mul_add(-cp_im, tw1r.mul_add(cp_re, ap_re));
+                            let out_a_im = tw1i.mul_add(cp_re, tw1r.mul_add(cp_im, ap_im));
+                            let out_c_re = two.mul_sub(ap_re, out_a_re);
+                            let out_c_im = two.mul_sub(ap_im, out_a_im);
+
+                            // Derive -j * tw1: (-j)(w_re + i*w_im) = w_im - i*w_re
+                            let nj_tw1r = tw1i;
+                            let nj_tw1i = -tw1r;
+
+                            // Stage s+1 butterfly: (B', D') pair with -j * tw_{s+1}[k]
+                            // out_B = B' + (-j*tw1) * D',  out_D = B' - (-j*tw1) * D'
+                            let out_b_re = nj_tw1i.mul_add(-dp_im, nj_tw1r.mul_add(dp_re, bp_re));
+                            let out_b_im = nj_tw1i.mul_add(dp_re, nj_tw1r.mul_add(dp_im, bp_im));
+                            let out_d_re = two.mul_sub(bp_re, out_b_re);
+                            let out_d_im = two.mul_sub(bp_im, out_b_im);
+
+                            // Store results
+                            out_a_re.store_slice(ra);
+                            out_a_im.store_slice(ia);
+                            out_b_re.store_slice(rb);
+                            out_b_im.store_slice(ib);
+                            out_c_re.store_slice(rc);
+                            out_c_im.store_slice(ic);
+                            out_d_re.store_slice(rd);
+                            out_d_im.store_slice(id);
+                        },
+                    );
+                },
+            );
+    }
+}
+
 /// Fused two-stage DIT butterfly for f32 (radix-2², narrow SIMD: f32x8)
 ///
 /// Processes two consecutive DIT stages in a single pass over memory,

--- a/src/kernels/dit.rs
+++ b/src/kernels/dit.rs
@@ -1297,40 +1297,6 @@ pub fn fft_dit_fused_2stage_f64_narrow<S: Simd>(
     )
 }
 
-/// Parallel fused two-stage DIT butterfly for f64 (radix-2², narrow SIMD: f64x4)
-///
-/// Same as [`fft_dit_fused_2stage_f64_narrow`] but parallelizes the inner loop
-/// using Rayon. Intended for the last stage of the FFT which spans the entire array
-/// and cannot be parallelized through recursion.
-#[cfg(feature = "parallel")]
-#[inline(never)]
-pub fn fft_dit_fused_2stage_f64_narrow_parallel<S: Simd>(
-    simd: S,
-    reals: &mut [f64],
-    imags: &mut [f64],
-    twiddles_s_re: &[f64],
-    twiddles_s_im: &[f64],
-    twiddles_s1_re: &[f64],
-    twiddles_s1_im: &[f64],
-    dist_s: usize,
-) {
-    simd.vectorize(
-        #[inline(always)]
-        || {
-            fft_dit_fused_2stage_simd_f64_narrow_parallel(
-                simd,
-                reals,
-                imags,
-                twiddles_s_re,
-                twiddles_s_im,
-                twiddles_s1_re,
-                twiddles_s1_im,
-                dist_s,
-            )
-        },
-    )
-}
-
 /// Fused two-stage DIT butterfly for f64 (radix-2², narrow SIMD: f64x4)
 #[inline(always)]
 fn fft_dit_fused_2stage_simd_f64_narrow<S: Simd>(

--- a/src/kernels/dit.rs
+++ b/src/kernels/dit.rs
@@ -1259,3 +1259,294 @@ fn fft_dit_chunk_n_simd_f32_narrow<S: Simd>(
             });
     }
 }
+
+/// Fused two-stage DIT butterfly for f64 (radix-2², narrow SIMD: f64x4)
+///
+/// Processes two consecutive DIT stages in a single pass over memory,
+/// halving memory traffic for the fused stages. Uses the radix-2² identity
+/// `W_{4D}^{k+D} = -j * W_{4D}^k` to derive the second-half twiddle factors
+/// trivially.
+///
+/// `twiddles_s` are for stage s (size dist_s), `twiddles_s1` are for stage s+1
+/// (only first dist_s elements needed; second half derived via -j multiply).
+#[inline(never)]
+pub fn fft_dit_fused_2stage_f64_narrow<S: Simd>(
+    simd: S,
+    reals: &mut [f64],
+    imags: &mut [f64],
+    twiddles_s_re: &[f64],
+    twiddles_s_im: &[f64],
+    twiddles_s1_re: &[f64],
+    twiddles_s1_im: &[f64],
+    dist_s: usize,
+) {
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            fft_dit_fused_2stage_simd_f64_narrow(
+                simd,
+                reals,
+                imags,
+                twiddles_s_re,
+                twiddles_s_im,
+                twiddles_s1_re,
+                twiddles_s1_im,
+                dist_s,
+            )
+        },
+    )
+}
+
+/// Fused two-stage DIT butterfly for f64 (radix-2², narrow SIMD: f64x4)
+#[inline(always)]
+fn fft_dit_fused_2stage_simd_f64_narrow<S: Simd>(
+    simd: S,
+    reals: &mut [f64],
+    imags: &mut [f64],
+    twiddles_s_re: &[f64],
+    twiddles_s_im: &[f64],
+    twiddles_s1_re: &[f64],
+    twiddles_s1_im: &[f64],
+    dist_s: usize,
+) {
+    const LANES: usize = 4;
+    let block_size = dist_s * 4; // two stages: 4 sub-blocks of dist_s
+    assert!(dist_s >= LANES);
+
+    // Outer loop over blocks of 4*dist_s elements.
+    // Using `for` (not `for_each`) for the same inlining reasons
+    // as in fft_dit_chunk_n_simd_f64.
+    for (reals_block, imags_block) in reals
+        .chunks_exact_mut(block_size)
+        .zip(imags.chunks_exact_mut(block_size))
+    {
+        // Split block into 4 sub-blocks of dist_s elements:
+        // A = [0..D), B = [D..2D), C = [2D..3D), D_blk = [3D..4D)
+        let (re_ab, re_cd) = reals_block.split_at_mut(dist_s * 2);
+        let (im_ab, im_cd) = imags_block.split_at_mut(dist_s * 2);
+        let (re_a, re_b) = re_ab.split_at_mut(dist_s);
+        let (im_a, im_b) = im_ab.split_at_mut(dist_s);
+        let (re_c, re_d) = re_cd.split_at_mut(dist_s);
+        let (im_c, im_d) = im_cd.split_at_mut(dist_s);
+
+        (re_a.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(re_b.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(re_c.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(re_d.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(im_a.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(im_b.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(im_c.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(im_d.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(twiddles_s_re.as_chunks::<LANES>().0.iter())
+            .zip(twiddles_s_im.as_chunks::<LANES>().0.iter())
+            .zip(twiddles_s1_re.as_chunks::<LANES>().0.iter())
+            .zip(twiddles_s1_im.as_chunks::<LANES>().0.iter())
+            .for_each(
+                |(
+                    ((((((((((ra, rb), rc), rd), ia), ib), ic), id), tw_s_re), tw_s_im), tw1_re),
+                    tw1_im,
+                )| {
+                    let two = f64x4::splat(simd, 2.0);
+
+                    // Load 4 data sub-blocks
+                    let a_re = f64x4::simd_from(simd, *ra);
+                    let a_im = f64x4::simd_from(simd, *ia);
+                    let b_re = f64x4::simd_from(simd, *rb);
+                    let b_im = f64x4::simd_from(simd, *ib);
+                    let c_re = f64x4::simd_from(simd, *rc);
+                    let c_im = f64x4::simd_from(simd, *ic);
+                    let d_re = f64x4::simd_from(simd, *rd);
+                    let d_im = f64x4::simd_from(simd, *id);
+
+                    // Load stage-s twiddles
+                    let tws_re = f64x4::simd_from(simd, *tw_s_re);
+                    let tws_im = f64x4::simd_from(simd, *tw_s_im);
+
+                    // Stage s butterfly: (A,B) pair
+                    // A' = A + tw_s * B,  B' = A - tw_s * B
+                    let ap_re = tws_im.mul_add(-b_im, tws_re.mul_add(b_re, a_re));
+                    let ap_im = tws_im.mul_add(b_re, tws_re.mul_add(b_im, a_im));
+                    let bp_re = two.mul_sub(a_re, ap_re);
+                    let bp_im = two.mul_sub(a_im, ap_im);
+
+                    // Stage s butterfly: (C,D) pair
+                    // C' = C + tw_s * D,  D' = C - tw_s * D
+                    let cp_re = tws_im.mul_add(-d_im, tws_re.mul_add(d_re, c_re));
+                    let cp_im = tws_im.mul_add(d_re, tws_re.mul_add(d_im, c_im));
+                    let dp_re = two.mul_sub(c_re, cp_re);
+                    let dp_im = two.mul_sub(c_im, cp_im);
+
+                    // Load stage-(s+1) twiddles (first half only)
+                    let tw1r = f64x4::simd_from(simd, *tw1_re);
+                    let tw1i = f64x4::simd_from(simd, *tw1_im);
+
+                    // Stage s+1 butterfly: (A', C') pair with tw_{s+1}[k]
+                    // out_A = A' + tw1 * C',  out_C = A' - tw1 * C'
+                    let out_a_re = tw1i.mul_add(-cp_im, tw1r.mul_add(cp_re, ap_re));
+                    let out_a_im = tw1i.mul_add(cp_re, tw1r.mul_add(cp_im, ap_im));
+                    let out_c_re = two.mul_sub(ap_re, out_a_re);
+                    let out_c_im = two.mul_sub(ap_im, out_a_im);
+
+                    // Derive -j * tw1: (-j)(w_re + i*w_im) = w_im - i*w_re
+                    let nj_tw1r = tw1i;
+                    let nj_tw1i = -tw1r;
+
+                    // Stage s+1 butterfly: (B', D') pair with -j * tw_{s+1}[k]
+                    // out_B = B' + (-j*tw1) * D',  out_D = B' - (-j*tw1) * D'
+                    let out_b_re = nj_tw1i.mul_add(-dp_im, nj_tw1r.mul_add(dp_re, bp_re));
+                    let out_b_im = nj_tw1i.mul_add(dp_re, nj_tw1r.mul_add(dp_im, bp_im));
+                    let out_d_re = two.mul_sub(bp_re, out_b_re);
+                    let out_d_im = two.mul_sub(bp_im, out_b_im);
+
+                    // Store results
+                    out_a_re.store_slice(ra);
+                    out_a_im.store_slice(ia);
+                    out_b_re.store_slice(rb);
+                    out_b_im.store_slice(ib);
+                    out_c_re.store_slice(rc);
+                    out_c_im.store_slice(ic);
+                    out_d_re.store_slice(rd);
+                    out_d_im.store_slice(id);
+                },
+            );
+    }
+}
+
+/// Fused two-stage DIT butterfly for f32 (radix-2², narrow SIMD: f32x8)
+///
+/// Processes two consecutive DIT stages in a single pass over memory,
+/// halving memory traffic for the fused stages. Uses the radix-2² identity
+/// `W_{4D}^{k+D} = -j * W_{4D}^k` to derive the second-half twiddle factors
+/// trivially.
+///
+/// `twiddles_s` are for stage s (size dist_s), `twiddles_s1` are for stage s+1
+/// (only first dist_s elements needed; second half derived via -j multiply).
+#[inline(never)]
+pub fn fft_dit_fused_2stage_f32_narrow<S: Simd>(
+    simd: S,
+    reals: &mut [f32],
+    imags: &mut [f32],
+    twiddles_s_re: &[f32],
+    twiddles_s_im: &[f32],
+    twiddles_s1_re: &[f32],
+    twiddles_s1_im: &[f32],
+    dist_s: usize,
+) {
+    simd.vectorize(
+        #[inline(always)]
+        || {
+            fft_dit_fused_2stage_simd_f32_narrow(
+                simd,
+                reals,
+                imags,
+                twiddles_s_re,
+                twiddles_s_im,
+                twiddles_s1_re,
+                twiddles_s1_im,
+                dist_s,
+            )
+        },
+    )
+}
+
+/// Fused two-stage DIT butterfly for f32 (radix-2², narrow SIMD: f32x8)
+#[inline(always)]
+fn fft_dit_fused_2stage_simd_f32_narrow<S: Simd>(
+    simd: S,
+    reals: &mut [f32],
+    imags: &mut [f32],
+    twiddles_s_re: &[f32],
+    twiddles_s_im: &[f32],
+    twiddles_s1_re: &[f32],
+    twiddles_s1_im: &[f32],
+    dist_s: usize,
+) {
+    const LANES: usize = 8;
+    let block_size = dist_s * 4;
+    assert!(dist_s >= LANES);
+
+    for (reals_block, imags_block) in reals
+        .chunks_exact_mut(block_size)
+        .zip(imags.chunks_exact_mut(block_size))
+    {
+        let (re_ab, re_cd) = reals_block.split_at_mut(dist_s * 2);
+        let (im_ab, im_cd) = imags_block.split_at_mut(dist_s * 2);
+        let (re_a, re_b) = re_ab.split_at_mut(dist_s);
+        let (im_a, im_b) = im_ab.split_at_mut(dist_s);
+        let (re_c, re_d) = re_cd.split_at_mut(dist_s);
+        let (im_c, im_d) = im_cd.split_at_mut(dist_s);
+
+        (re_a.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(re_b.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(re_c.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(re_d.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(im_a.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(im_b.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(im_c.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(im_d.as_chunks_mut::<LANES>().0.iter_mut())
+            .zip(twiddles_s_re.as_chunks::<LANES>().0.iter())
+            .zip(twiddles_s_im.as_chunks::<LANES>().0.iter())
+            .zip(twiddles_s1_re.as_chunks::<LANES>().0.iter())
+            .zip(twiddles_s1_im.as_chunks::<LANES>().0.iter())
+            .for_each(
+                |(
+                    ((((((((((ra, rb), rc), rd), ia), ib), ic), id), tw_s_re), tw_s_im), tw1_re),
+                    tw1_im,
+                )| {
+                    let two = f32x8::splat(simd, 2.0);
+
+                    let a_re = f32x8::simd_from(simd, *ra);
+                    let a_im = f32x8::simd_from(simd, *ia);
+                    let b_re = f32x8::simd_from(simd, *rb);
+                    let b_im = f32x8::simd_from(simd, *ib);
+                    let c_re = f32x8::simd_from(simd, *rc);
+                    let c_im = f32x8::simd_from(simd, *ic);
+                    let d_re = f32x8::simd_from(simd, *rd);
+                    let d_im = f32x8::simd_from(simd, *id);
+
+                    let tws_re = f32x8::simd_from(simd, *tw_s_re);
+                    let tws_im = f32x8::simd_from(simd, *tw_s_im);
+
+                    // Stage s butterfly: (A,B) pair
+                    let ap_re = tws_im.mul_add(-b_im, tws_re.mul_add(b_re, a_re));
+                    let ap_im = tws_im.mul_add(b_re, tws_re.mul_add(b_im, a_im));
+                    let bp_re = two.mul_sub(a_re, ap_re);
+                    let bp_im = two.mul_sub(a_im, ap_im);
+
+                    // Stage s butterfly: (C,D) pair
+                    let cp_re = tws_im.mul_add(-d_im, tws_re.mul_add(d_re, c_re));
+                    let cp_im = tws_im.mul_add(d_re, tws_re.mul_add(d_im, c_im));
+                    let dp_re = two.mul_sub(c_re, cp_re);
+                    let dp_im = two.mul_sub(c_im, cp_im);
+
+                    let tw1r = f32x8::simd_from(simd, *tw1_re);
+                    let tw1i = f32x8::simd_from(simd, *tw1_im);
+
+                    // Stage s+1 butterfly: (A', C') pair with tw_{s+1}[k]
+                    let out_a_re = tw1i.mul_add(-cp_im, tw1r.mul_add(cp_re, ap_re));
+                    let out_a_im = tw1i.mul_add(cp_re, tw1r.mul_add(cp_im, ap_im));
+                    let out_c_re = two.mul_sub(ap_re, out_a_re);
+                    let out_c_im = two.mul_sub(ap_im, out_a_im);
+
+                    // Derive -j * tw1
+                    let nj_tw1r = tw1i;
+                    let nj_tw1i = -tw1r;
+
+                    // Stage s+1 butterfly: (B', D') pair with -j * tw_{s+1}[k]
+                    let out_b_re = nj_tw1i.mul_add(-dp_im, nj_tw1r.mul_add(dp_re, bp_re));
+                    let out_b_im = nj_tw1i.mul_add(dp_re, nj_tw1r.mul_add(dp_im, bp_im));
+                    let out_d_re = two.mul_sub(bp_re, out_b_re);
+                    let out_d_im = two.mul_sub(bp_im, out_b_im);
+
+                    out_a_re.store_slice(ra);
+                    out_a_im.store_slice(ia);
+                    out_b_re.store_slice(rb);
+                    out_b_im.store_slice(ib);
+                    out_c_re.store_slice(rc);
+                    out_c_im.store_slice(ic);
+                    out_d_re.store_slice(rd);
+                    out_d_im.store_slice(id);
+                },
+            );
+    }
+}


### PR DESCRIPTION
Stacked on top of #103

Adds parallelism to the FFT kernel scaffold, which lets us parallelize the final few stages that aren't parallelized by recursion.

Recursion is still preferable because it provides natural cache locality and makes the algorithm cache-oblivious.

Performance vs main: -27% time taken on Zen4, -38% time taken on M4 
measured on `cargo run --profile=profiling --all-features --example benchmark -- 64 28 5`