### PR TITLE
Enable the `parallel` feature by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rayon = { version = "1.11.0", optional = true }
 fearless_simd = "0.4.1"
 
 [features]
-default = []
+default = ["parallel"]
 complex-nums = ["dep:num-complex", "dep:bytemuck"]
 parallel = ["dep:rayon"]
 bench-internals = ["complex-nums"]


### PR DESCRIPTION
There is no drawback to it other than dependency sprawl, and performance out of the box is much improved for our target use cases of large sizes.